### PR TITLE
MAGN-4584: Centering class buttons

### DIFF
--- a/src/DynamoCore/UI/LibraryWrapPanel.cs
+++ b/src/DynamoCore/UI/LibraryWrapPanel.cs
@@ -61,6 +61,11 @@ namespace Dynamo.Controls
             }
 
             double x = 0, y = 0, currentRowHeight = 0;
+
+            int itemsPerRow = (int)Math.Floor(finalSize.Width / classObjectWidth);
+            double sizeBetweenItems = (finalSize.Width - itemsPerRow*classObjectWidth) / (itemsPerRow+1);
+
+
             foreach (UIElement child in this.Children)
             {
                 var desiredSize = child.DesiredSize;
@@ -71,8 +76,8 @@ namespace Dynamo.Controls
                     currentRowHeight = 0;
                 }
 
-                child.Arrange(new Rect(x, y, desiredSize.Width, desiredSize.Height));
-                x = x + desiredSize.Width;
+                child.Arrange(new Rect(x + sizeBetweenItems, y, desiredSize.Width, desiredSize.Height));
+                x = x + desiredSize.Width + sizeBetweenItems;
                 if (desiredSize.Height > currentRowHeight)
                     currentRowHeight = desiredSize.Height;
             }


### PR DESCRIPTION
# Preface

On resizing, the icon squares flow. Arrange the icons such that they are center aligned horizontally to the big container, with same space on both side. For example
![image](https://cloud.githubusercontent.com/assets/8158404/4271663/e340ccc6-3cda-11e4-9a7f-8951b23b39c2.png)
 All gaps are of same length (tolerance 1px)
# Solution

Arrange children in LibraryWrapPanel.
# Before

![image](https://cloud.githubusercontent.com/assets/8158404/4271732/97063318-3cdb-11e4-9974-4b042bcbdb52.png)
# After

![image](https://cloud.githubusercontent.com/assets/8158404/4271699/492cf17c-3cdb-11e4-940c-fed7ca543d83.png)
# Reviewers

@Benglin,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-4584 DUI: During resize in StandardPanel subcategories should be centered at their imaginative columns](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4584)
