### PR TITLE
StandardPanelViewModel is introduced

### DIFF
--- a/src/DynamoCore/DynamoCore.csproj
+++ b/src/DynamoCore/DynamoCore.csproj
@@ -301,6 +301,7 @@ limitations under the License.
     <Compile Include="ViewModels\EndlessGridViewModel.cs" />
     <Compile Include="ViewModels\InfoBubbleViewModel.cs" />
     <Compile Include="ViewModels\IWatchViewModel.cs" />
+    <Compile Include="ViewModels\StandardPanelViewModel.cs" />
     <Compile Include="ViewModels\Watch3DFullscreenViewModel.cs" />
     <Compile Include="ViewModels\WatchViewModel.cs" />
     <Compile Include="Search\BrowserInternalElement.cs" />

--- a/src/DynamoCore/Search/BrowserInternalElement.cs
+++ b/src/DynamoCore/Search/BrowserInternalElement.cs
@@ -253,6 +253,8 @@ namespace Dynamo.Nodes.Search
 
         #endregion
 
+        #region These properties will be moved to StandardPanelViewModel in near future
+
         /// <summary>
         /// Specifies whether or not instance should be shown as StandardPanel.
         /// </summary>
@@ -311,6 +313,8 @@ namespace Dynamo.Nodes.Search
             }
         }
 
+        #endregion
+
         public ClassInformation()
             : base()
         {
@@ -319,6 +323,8 @@ namespace Dynamo.Nodes.Search
             queryMembers = new List<BrowserInternalElement>();
             Focusable = false;
         }
+
+        #region These properties stay here (ClassInformation)
 
         private List<BrowserInternalElement> createMembers;
         public IEnumerable<BrowserInternalElement> CreateMembers
@@ -337,6 +343,8 @@ namespace Dynamo.Nodes.Search
         {
             get { return this.queryMembers; }
         }
+
+        #endregion
 
         public void PopulateMemberCollections(BrowserItem element)
         {

--- a/src/DynamoCore/UI/ClassObjectTemplateSelector.cs
+++ b/src/DynamoCore/UI/ClassObjectTemplateSelector.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using Dynamo.Nodes.Search;
+using Dynamo.ViewModels;
 
 namespace Dynamo.Controls
 {
@@ -12,7 +13,7 @@ namespace Dynamo.Controls
 
         public override DataTemplate SelectTemplate(object item, DependencyObject container)
         {
-            if (item is ClassInformation)
+            if (item is StandardPanelViewModel)
                 return ClassDetailsTemplate;
 
             if (item is BrowserInternalElement)

--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml
@@ -66,8 +66,12 @@
                                        VerticalAlignment="Center"
                                        TextAlignment="Center"
                                        Foreground="#DDD"
-                                       FontSize="20px"
-                                       Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}"></TextBlock>
+                                       FontSize="20px">
+                                <TextBlock.Text>
+                                    <Binding Path="Content"
+                                             RelativeSource="{RelativeSource TemplatedParent}" />
+                                </TextBlock.Text>
+                            </TextBlock>
                         </Grid>
                         <ControlTemplate.Triggers>
                             <Trigger Property="Button.IsMouseOver"

--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml.cs
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using Dynamo.Nodes.Search;
 using Dynamo.Search;
 using Dynamo.Search.SearchElements;
+using Dynamo.ViewModels;
 
 namespace Dynamo.UI.Controls
 {
@@ -25,7 +26,7 @@ namespace Dynamo.UI.Controls
         // Specifies if all Lists (CreateMembers, QueryMembers and ActionMembers) are not empty
         // and should be presented on StandardPanel.
         private bool areAllListsPresented;
-        private ClassInformation castedDataContext;
+        private StandardPanelViewModel viewModel;
 
         public StandardPanel()
         {
@@ -42,18 +43,18 @@ namespace Dynamo.UI.Controls
             var senderTag = (sender as FrameworkElement).Tag.ToString();
 
             // User clicked on selected header. No need to change ItemsSource.
-            if (senderTag == castedDataContext.CurrentDisplayMode.ToString())
+            if (senderTag == viewModel.CurrentDisplayMode.ToString())
                 return;
 
             if (senderTag == QueryHeaderTag)
             {
-                castedDataContext.CurrentDisplayMode = ClassInformation.DisplayMode.Query;
-                secondaryMembers.ItemsSource = castedDataContext.QueryMembers;
+                viewModel.CurrentDisplayMode = StandardPanelViewModel.DisplayMode.Query;
+                secondaryMembers.ItemsSource = viewModel.QueryMembers;
             }
             else
             {
-                castedDataContext.CurrentDisplayMode = ClassInformation.DisplayMode.Action;
-                secondaryMembers.ItemsSource = castedDataContext.ActionMembers;
+                viewModel.CurrentDisplayMode = StandardPanelViewModel.DisplayMode.Action;
+                secondaryMembers.ItemsSource = viewModel.ActionMembers;
             }
 
             TruncateSecondaryMembers();
@@ -83,54 +84,54 @@ namespace Dynamo.UI.Controls
 
         private void GridDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            castedDataContext = this.DataContext as ClassInformation;
-            if (castedDataContext == null)
+            viewModel = this.DataContext as StandardPanelViewModel;
+            if (viewModel == null)
                 return;
 
-            bool hasCreateMembers = castedDataContext.CreateMembers.Any();
-            bool hasActionMembers = castedDataContext.ActionMembers.Any();
-            bool hasQueryMembers = castedDataContext.QueryMembers.Any();
+            bool hasCreateMembers = viewModel.CreateMembers.Any();
+            bool hasActionMembers = viewModel.ActionMembers.Any();
+            bool hasQueryMembers = viewModel.QueryMembers.Any();
 
             areAllListsPresented = hasCreateMembers && hasActionMembers && hasQueryMembers;
 
             // Hide all headers by default.
-            castedDataContext.IsPrimaryHeaderVisible = false;
-            castedDataContext.IsSecondaryHeaderLeftVisible = false;
-            castedDataContext.IsSecondaryHeaderRightVisible = false;
+            viewModel.IsPrimaryHeaderVisible = false;
+            viewModel.IsSecondaryHeaderLeftVisible = false;
+            viewModel.IsSecondaryHeaderRightVisible = false;
 
             // Set default values.
-            castedDataContext.PrimaryHeaderGroup = SearchElementGroup.Create;
-            castedDataContext.SecondaryHeaderLeftGroup = SearchElementGroup.Query;
-            castedDataContext.SecondaryHeaderRightGroup = SearchElementGroup.Action;
+            viewModel.PrimaryHeaderGroup = SearchElementGroup.Create;
+            viewModel.SecondaryHeaderLeftGroup = SearchElementGroup.Query;
+            viewModel.SecondaryHeaderRightGroup = SearchElementGroup.Action;
 
-            castedDataContext.CurrentDisplayMode = ClassInformation.DisplayMode.None;
+            viewModel.CurrentDisplayMode = StandardPanelViewModel.DisplayMode.None;
 
             // Case when CreateMembers list is not empty.
             // We should present CreateMembers in primaryMembers.            
             if (hasCreateMembers)
             {
-                castedDataContext.IsPrimaryHeaderVisible = true;
-                primaryMembers.ItemsSource = castedDataContext.CreateMembers;
+                viewModel.IsPrimaryHeaderVisible = true;
+                primaryMembers.ItemsSource = viewModel.CreateMembers;
 
                 if (hasQueryMembers)
                 {
-                    castedDataContext.IsSecondaryHeaderLeftVisible = true;
+                    viewModel.IsSecondaryHeaderLeftVisible = true;
 
-                    secondaryMembers.ItemsSource = castedDataContext.QueryMembers;
+                    secondaryMembers.ItemsSource = viewModel.QueryMembers;
                 }
 
                 if (hasActionMembers)
                 {
-                    castedDataContext.IsSecondaryHeaderRightVisible = true;
+                    viewModel.IsSecondaryHeaderRightVisible = true;
 
                     if (!hasQueryMembers)
-                        secondaryMembers.ItemsSource = castedDataContext.ActionMembers;
+                        secondaryMembers.ItemsSource = viewModel.ActionMembers;
                 }
 
                 // For case when all lists are presented we should specify
                 // correct CurrentDisplayMode.
                 if (hasQueryMembers && hasActionMembers)
-                    castedDataContext.CurrentDisplayMode = ClassInformation.DisplayMode.Query;
+                    viewModel.CurrentDisplayMode = StandardPanelViewModel.DisplayMode.Query;
 
                 TruncateSecondaryMembers();
                 return;
@@ -141,14 +142,14 @@ namespace Dynamo.UI.Controls
             // Depending on availibility of QueryMembers it will be shown as secondaryHeaderLeft.
             if (hasActionMembers)
             {
-                castedDataContext.IsPrimaryHeaderVisible = true;
-                castedDataContext.PrimaryHeaderGroup = SearchElementGroup.Action;
-                primaryMembers.ItemsSource = castedDataContext.ActionMembers;
+                viewModel.IsPrimaryHeaderVisible = true;
+                viewModel.PrimaryHeaderGroup = SearchElementGroup.Action;
+                primaryMembers.ItemsSource = viewModel.ActionMembers;
 
                 if (hasQueryMembers)
                 {
-                    castedDataContext.IsSecondaryHeaderLeftVisible = true;
-                    secondaryMembers.ItemsSource = castedDataContext.QueryMembers;
+                    viewModel.IsSecondaryHeaderLeftVisible = true;
+                    secondaryMembers.ItemsSource = viewModel.QueryMembers;
                 }
 
                 TruncateSecondaryMembers();
@@ -159,21 +160,21 @@ namespace Dynamo.UI.Controls
             // If QueryMembers is not empty the list will be presented in primaryMembers. 
             if (hasQueryMembers)
             {
-                castedDataContext.PrimaryHeaderGroup = SearchElementGroup.Query;
-                primaryMembers.ItemsSource = castedDataContext.QueryMembers;
+                viewModel.PrimaryHeaderGroup = SearchElementGroup.Query;
+                primaryMembers.ItemsSource = viewModel.QueryMembers;
             }
         }
 
         private void OnMoreButtonClick(object sender, RoutedEventArgs e)
         {
-            if (castedDataContext.HiddenMembers != null)
+            if (viewModel.HiddenMembers != null)
             {
                 var members = secondaryMembers.ItemsSource as IEnumerable<BrowserInternalElement>;
                 var allMembers = members.ToList();
-                allMembers.AddRange(castedDataContext.HiddenMembers);
+                allMembers.AddRange(viewModel.HiddenMembers);
 
                 secondaryMembers.ItemsSource = allMembers;
-                castedDataContext.HiddenMembers = null;
+                viewModel.HiddenMembers = null;
             }
         }
 
@@ -182,7 +183,7 @@ namespace Dynamo.UI.Controls
             var members = secondaryMembers.ItemsSource as IEnumerable<BrowserInternalElement>;
             if (members != null && members.Count() > TruncatedMembersCount)
             {
-                castedDataContext.HiddenMembers = members.Skip(TruncatedMembersCount);
+                viewModel.HiddenMembers = members.Skip(TruncatedMembersCount);
                 secondaryMembers.ItemsSource = members.Take(TruncatedMembersCount);
             }
         }

--- a/src/DynamoCore/UI/LibraryWrapPanel.cs
+++ b/src/DynamoCore/UI/LibraryWrapPanel.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using Dynamo.Nodes.Search;
 using Dynamo.UI.Controls;
 using Dynamo.Utilities;
+using Dynamo.ViewModels;
 
 namespace Dynamo.Controls
 {
@@ -24,7 +25,7 @@ namespace Dynamo.Controls
             // ListView should never be null.
             var classListView = WPF.FindUpVisualTree<ListView>(this);
             collection = classListView.ItemsSource as ObservableCollection<BrowserItem>;
-            collection.Add(new ClassInformation());
+            collection.Add(new StandardPanelViewModel());
             classListView.SelectionChanged += OnClassViewSelectionChanged;
 
             base.OnInitialized(e);
@@ -116,7 +117,7 @@ namespace Dynamo.Controls
 
         private int GetClassInformationIndex()
         {
-            var query = collection.Select(c => c).Where(c => c is ClassInformation);
+            var query = collection.Select(c => c).Where(c => c is StandardPanelViewModel);
             var classObjectBase = query.ElementAt(0);
             return collection.IndexOf(classObjectBase);
         }
@@ -133,7 +134,7 @@ namespace Dynamo.Controls
             var classObjectBase = collection[currentClassInformationIndex];
 
             // If there is no selection, then mark the StandardPanel as hidden.
-            var classInformation = classObjectBase as ClassInformation;
+            var classInformation = classObjectBase as StandardPanelViewModel;
             if (classInformation != null && (selectedClassProspectiveIndex == -1))
                 return;
 

--- a/src/DynamoCore/UI/SubclassesTemplateSelector.cs
+++ b/src/DynamoCore/UI/SubclassesTemplateSelector.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using Dynamo.Nodes.Search;
+using Dynamo.ViewModels;
 
 namespace Dynamo.Controls
 {
@@ -12,7 +13,7 @@ namespace Dynamo.Controls
 
         public override DataTemplate SelectTemplate(object item, DependencyObject container)
         {
-            if (item is ClassInformation)
+            if (item is StandardPanelViewModel)
                 return ClassDetailsTemplate;
 
             if (item is BrowserRootElement)

--- a/src/DynamoCore/ViewModels/StandardPanelViewModel.cs
+++ b/src/DynamoCore/ViewModels/StandardPanelViewModel.cs
@@ -1,12 +1,121 @@
 ﻿using System;
 using System.Collections.Generic;
+using Dynamo.Nodes.Search;
 using System.Linq;
-using System.Text;
-using Microsoft.Practices.Prism.ViewModel;
+using Dynamo.Search;
 
 namespace Dynamo.ViewModels
 {
-    public class StandardPanelViewModel : NotificationObject
+    public class StandardPanelViewModel : BrowserItem
     {
+        #region BrowserItem abstract members implementation
+
+        public override System.Collections.ObjectModel.ObservableCollection<BrowserItem> Items
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override string Name
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #endregion
+
+        private ClassInformation model;
+
+        public IEnumerable<BrowserInternalElement> CreateMembers
+        {
+            get { return model.CreateMembers; }
+        }
+
+        public IEnumerable<BrowserInternalElement> ActionMembers
+        {
+            get { return model.ActionMembers; }
+        }
+
+        public IEnumerable<BrowserInternalElement> QueryMembers
+        {
+            get { return model.QueryMembers; }
+        }
+
+        /// <summary>
+        /// Specifies whether or not instance should be shown as StandardPanel.
+        /// </summary>
+        public bool ClassDetailsVisibility
+        {
+            get
+            {
+                return CreateMembers.Any() || ActionMembers.Any() || QueryMembers.Any();
+            }
+        }
+
+        public SearchElementGroup PrimaryHeaderGroup { get; set; }
+        public SearchElementGroup SecondaryHeaderLeftGroup { get; set; }
+        public SearchElementGroup SecondaryHeaderRightGroup { get; set; }
+        public bool IsPrimaryHeaderVisible { get; set; }
+        public bool IsSecondaryHeaderLeftVisible { get; set; }
+        public bool IsSecondaryHeaderRightVisible { get; set; }
+
+        public enum DisplayMode { None, Query, Action };
+
+        /// <summary>
+        /// Specifies which of QueryMembers of ActionMembers list is active for the moment.
+        /// If any of CreateMembers, ActionMembers or QueryMembers lists is empty
+        /// it returns 'None'.
+        /// </summary>
+        private DisplayMode currentDisplayMode;
+        public DisplayMode CurrentDisplayMode
+        {
+            get
+            {
+                return currentDisplayMode;
+            }
+            set
+            {
+                currentDisplayMode = value;
+                RaisePropertyChanged("CurrentDisplayMode");
+            }
+        }
+
+        private IEnumerable<BrowserInternalElement> hiddenMembers;
+        public IEnumerable<BrowserInternalElement> HiddenMembers
+        {
+            get { return hiddenMembers; }
+            set
+            {
+                hiddenMembers = value;
+                RaisePropertyChanged("IsMoreButtonVisible");
+            }
+        }
+
+        public bool IsMoreButtonVisible
+        {
+            get
+            {
+                return HiddenMembers != null && HiddenMembers.Any();
+            }
+        }
+
+        public StandardPanelViewModel()
+            : this(new ClassInformation())
+        { }
+
+        public StandardPanelViewModel(ClassInformation classInfo)
+        {
+            model = classInfo;
+        }
+
+        public void PopulateMemberCollections(BrowserItem element)
+        {
+            model.PopulateMemberCollections(element);
+        }
     }
 }


### PR DESCRIPTION
#### Purpose

Currently we are at point when `ClassInformation` class includes a lot of information which connected with UI not data. It was decided to add `ViewModel` for `StandardPanel`. At `Model` layer for `StandardPanel` will be used `ClassInformation`.
#### Modifications

Created `StandardPanelViewModel` as derived from `BrowserItem`. `StandardPanelViewModel` replaces `ClassInformation` in `LibarryWrapPanel`, `ClassObjectTemplateSelector`, `StandardPanel`.
#### Additional references

[MAGN-4641](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4641).
#### Reviewers

@Benglin, please take a look at initial part of work. For now I just replaced `ClassInformation` to `StandardPanelViewModel`. Without improving the logic as you proposed. I would like ensure that I am on right way. Thank you.
