### PR TITLE
DUI: long names truncation(methods)

### DIFF
--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml
@@ -132,7 +132,8 @@
                      Grid.Row="1"
                      Background="Transparent"
                      BorderBrush="Transparent"
-                     ItemContainerStyle="{DynamicResource ListBoxItemStyle}">
+                     ItemContainerStyle="{DynamicResource ListBoxItemStyle}"
+                     ScrollViewer.HorizontalScrollBarVisibility="Hidden">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal">
@@ -233,7 +234,8 @@
                      Grid.ColumnSpan="2"
                      Background="Transparent"
                      BorderBrush="Transparent"
-                     ItemContainerStyle="{DynamicResource ListBoxItemStyle}">
+                     ItemContainerStyle="{DynamicResource ListBoxItemStyle}"
+                     ScrollViewer.HorizontalScrollBarVisibility="Hidden">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal">

--- a/src/DynamoCore/UI/DynamoTextBox.cs
+++ b/src/DynamoCore/UI/DynamoTextBox.cs
@@ -10,6 +10,7 @@ using Dynamo.Models;
 using Dynamo.UI;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
+using Dynamo.Search;
 
 using DynCmd = Dynamo.ViewModels.DynamoViewModel;
 using System.Windows.Controls.Primitives;
@@ -538,8 +539,8 @@ namespace Dynamo.UI.Controls
                     break;
 
                 case Side.Right:
-                    x = target.Width + 2.5*gap;
-                    var availableHeight = Application.Current.MainWindow.ActualHeight - popup.Height 
+                    x = WPF.FindUpVisualTree<SearchView>(this.PlacementTarget).ActualWidth + 2.5*gap;
+                    var availableHeight = Application.Current.MainWindow.ActualHeight - popup.Height
                         - (targetLocation.Y + Configurations.NodeButtonHeight);
                     if (availableHeight < Configurations.BottomPanelHeight)
                         y = availableHeight - (Configurations.BottomPanelHeight+gap*4);


### PR DESCRIPTION
Sorry, I just wanted to rename branch from `DUI-LongNamesTruncation(classes)` to `DUI-LongNamesTruncation(methods)`, but it was created another branch, seems I have done something wrong.

Old one PR is [here](https://github.com/Benglin/Dynamo/pull/59).

I have done truncation with using `TextTrimming` property. But I couldn't find solution to cut it with 2 dots. I don't think that EB would be pleased.
# Reviewers

@Benglin,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-4376 Long names need to be truncated](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4376)
