### PR TITLE
DUI: Object type check should be made more robust

### DIFF
--- a/src/DynamoCore/UI/LibraryWrapPanel.cs
+++ b/src/DynamoCore/UI/LibraryWrapPanel.cs
@@ -76,7 +76,8 @@ namespace Dynamo.Controls
                     currentRowHeight = 0;
                 }
 
-                if (child.DesiredSize.Width > classObjectWidth) //Then it's Standard panel, we do not need margin it.
+                if ((child as FrameworkElement).DataContext is ClassInformation)
+                //Then it's Standard panel, we do not need margin it.
                 {
                     child.Arrange(new Rect(x, y, desiredSize.Width, desiredSize.Height));
                     x = x + desiredSize.Width;


### PR DESCRIPTION
The following problem is from https://github.com/Benglin/Dynamo/pull/60 this pull request, it should be fixed:

There is a foreach loop in `ArrangeOverride` method of `LibraryWrapPanel` class. It checks to see if a given child is `StandardPanel` or a regular class icon. The way it checks is by going through the width of the child object, this is not a reliable way of checking.

Instead, the check should be done by checking the runtime object type 
(I think it is StandardPanel object). <-- That didn't work, but check of `DataContext` did.
just for fun... i needed to try :cat: 

Reviewers
@Benglin,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-4682 Object type check should be made more robust](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4682)
