### PR TITLE
Change the logic of secondaryMembers list population

### DIFF
--- a/src/DynamoCore/Search/BrowserInternalElement.cs
+++ b/src/DynamoCore/Search/BrowserInternalElement.cs
@@ -264,9 +264,9 @@ namespace Dynamo.Nodes.Search
             }
         }
 
-        public SearchElementGroup PrimaryHeaderGroup { get; set; }
-        public SearchElementGroup SecondaryHeaderLeftGroup { get; set; }
-        public SearchElementGroup SecondaryHeaderRightGroup { get; set; }
+        public string PrimaryHeaderText { get; set; }
+        public string SecondaryHeaderLeftText { get; set; }
+        public string SecondaryHeaderRightText { get; set; }
         public bool IsPrimaryHeaderVisible { get; set; }
         public bool IsSecondaryHeaderLeftVisible { get; set; }
         public bool IsSecondaryHeaderRightVisible { get; set; }

--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml
@@ -13,7 +13,6 @@
     <UserControl.Resources>
         <controls:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
         <controls:BrowserItemToBooleanConverter x:Key="BrowserItemToBooleanConverter" />
-        <controls:SearchElementGroupToHeaderConverter x:Key="SearchElementGroupToHeaderConverter" />
         <controls:DisplayModeToTextDecorationsConverter x:Key="DisplayModeToTextDecorationsConverter" />
         <Style x:Key="ListBoxItemStyle"
                TargetType="{x:Type ListBoxItem}">
@@ -116,15 +115,12 @@
                            Foreground="#777777"
                            VerticalAlignment="Center"
                            FontSize="9"
-                           Margin="16,0,0,0">
+                           Margin="16,0,0,0"
+                           Text="{Binding PrimaryHeaderText}">
                     <TextBlock.Visibility>
                         <Binding Path="IsPrimaryHeaderVisible"
                                  Converter="{StaticResource BoolToVisibilityCollapsedConverter}" />
                     </TextBlock.Visibility>
-                    <TextBlock.Text>
-                        <Binding Path="PrimaryHeaderGroup"
-                                 Converter="{StaticResource SearchElementGroupToHeaderConverter}" />
-                    </TextBlock.Text>
                     <TextBlock.TextDecorations>
                         <TextDecoration Location="Underline"
                                         PenOffset="2"
@@ -169,15 +165,12 @@
                                VerticalAlignment="Center"
                                FontSize="9"
                                Margin="0,0,13.5,0"
-                               Style="{StaticResource secondaryMembersTextBlock}">
+                               Style="{StaticResource secondaryMembersTextBlock}"
+                               Text="{Binding SecondaryHeaderLeftText}">
                         <TextBlock.Visibility>
                             <Binding Path="IsSecondaryHeaderLeftVisible"
                                      Converter="{StaticResource BoolToVisibilityCollapsedConverter}" />
                         </TextBlock.Visibility>
-                        <TextBlock.Text>
-                            <Binding Path="SecondaryHeaderLeftGroup"
-                                     Converter="{StaticResource SearchElementGroupToHeaderConverter}" />
-                        </TextBlock.Text>
                         <TextBlock.TextDecorations>
                             <TextDecoration PenOffset="2"
                                             PenOffsetUnit="Pixel">
@@ -207,15 +200,12 @@
                                PreviewMouseDown="OnHeaderMouseDown"
                                VerticalAlignment="Center"
                                FontSize="9"
-                               Style="{StaticResource secondaryMembersTextBlock}">
+                               Style="{StaticResource secondaryMembersTextBlock}"
+                               Text="{Binding SecondaryHeaderRightText}">
                         <TextBlock.Visibility>
                             <Binding Path="IsSecondaryHeaderRightVisible"
                                      Converter="{StaticResource BoolToVisibilityCollapsedConverter}" />
                         </TextBlock.Visibility>
-                        <TextBlock.Text>
-                            <Binding Path="SecondaryHeaderRightGroup"
-                                     Converter="{StaticResource SearchElementGroupToHeaderConverter}" />
-                        </TextBlock.Text>
                         <TextBlock.TextDecorations>
                             <TextDecoration PenOffset="2"
                                             PenOffsetUnit="Pixel">

--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml.cs
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml.cs
@@ -16,6 +16,9 @@ namespace Dynamo.UI.Controls
     {
         #region Constants
 
+        private const string CreateHeaderText = "CREATE";
+        private const string QueryHeaderText = "QUERY";
+        private const string ActionHeaderText = "ACTIONS";
         private const string ActionHeaderTag = "Action";
         private const string QueryHeaderTag = "Query";
         private const int TruncatedMembersCount = 4;
@@ -99,9 +102,9 @@ namespace Dynamo.UI.Controls
             castedDataContext.IsSecondaryHeaderRightVisible = false;
 
             // Set default values.
-            castedDataContext.PrimaryHeaderGroup = SearchElementGroup.Create;
-            castedDataContext.SecondaryHeaderLeftGroup = SearchElementGroup.Query;
-            castedDataContext.SecondaryHeaderRightGroup = SearchElementGroup.Action;
+            castedDataContext.PrimaryHeaderText = CreateHeaderText;
+            castedDataContext.SecondaryHeaderLeftText = QueryHeaderText;
+            castedDataContext.SecondaryHeaderRightText = ActionHeaderText;
 
             castedDataContext.CurrentDisplayMode = ClassInformation.DisplayMode.None;
 
@@ -142,7 +145,7 @@ namespace Dynamo.UI.Controls
             if (hasActionMembers)
             {
                 castedDataContext.IsPrimaryHeaderVisible = true;
-                castedDataContext.PrimaryHeaderGroup = SearchElementGroup.Action;
+                castedDataContext.PrimaryHeaderText = ActionHeaderText;
                 primaryMembers.ItemsSource = castedDataContext.ActionMembers;
 
                 if (hasQueryMembers)
@@ -161,7 +164,7 @@ namespace Dynamo.UI.Controls
             // If QueryMembers is not empty the list will be presented in primaryMembers. 
             if (hasQueryMembers)
             {
-                castedDataContext.PrimaryHeaderGroup = SearchElementGroup.Query;
+                castedDataContext.PrimaryHeaderText = QueryHeaderText;
                 primaryMembers.ItemsSource = castedDataContext.QueryMembers;
             }
         }

--- a/src/DynamoCore/UI/Converters.cs
+++ b/src/DynamoCore/UI/Converters.cs
@@ -1689,31 +1689,6 @@ namespace Dynamo.Controls
         }
     }
 
-    /// This converter displays correct header text on StandarPanel
-    /// by using SearchElement as value parameter.
-    public class SearchElementGroupToHeaderConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            switch ((SearchElementGroup)value)
-            {
-                case SearchElementGroup.Create:
-                    return "CREATE";
-                case SearchElementGroup.Action:
-                    return "ACTIONS";
-                case SearchElementGroup.Query:
-                    return "QUERY";
-                default:
-                    return "Header is undefined";
-            }
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
     /// This converter makes TextBlock UnderLine.Pen.Thickness = 1 if it is currently selected.
     /// To know for which TextBlock the converter works the parameter used.
     /// Converter is used on StandardPanel.


### PR DESCRIPTION
#### Purpose

implement more elegant solution of show/hide "More" button.
#### Modifications

`HiddenMembers` list is removed. Functions `OnMoreButtonClick` and `TruncateSecondaryMembers` are rewritten to more elegant view. Property `IsMoreButtonVisisble` is changed manually.
#### Additional references

It was decided not introduce `StandardPanelViewModel`. But other comments of https://github.com/Benglin/Dynamo/pull/51 is addressed.
#### Reviewers

@Benglin, it is hard to use `ShowExtendedMembers` in simple way as you proposed in https://github.com/Benglin/Dynamo/pull/51#discussion_r17583342. because we don't know for which collection the button should be add. It can be any of three collections. I am proposing similar solution but logic actually situated in two methods not lists` properties. Please, take a look.
