### PR TITLE
MAGN-4662: Tooltips for operators are 'sticky'

### DIFF
--- a/src/DynamoCore/UI/DynamoTextBox.cs
+++ b/src/DynamoCore/UI/DynamoTextBox.cs
@@ -298,7 +298,7 @@ namespace Dynamo.Nodes
 
         bool shift, enter;
         public CodeNodeTextBox(string s)
-            : base( s)
+            : base(s)
         {
             shift = enter = false;
 
@@ -514,6 +514,11 @@ namespace Dynamo.UI.Controls
             }
             dispatcherTimer.Stop();
             this.DataContext = dataContext;
+
+            // This line is needed to change position of Popup.
+            // As position changed PlacementCallback is called and
+            // Popup placed correctly.
+            this.HorizontalOffset++;
         }
 
         private void CloseLibraryToolTipPopup(object sender, EventArgs e)
@@ -569,8 +574,5 @@ namespace Dynamo.UI.Controls
                 }
             };
         }
-
-
-        
     }
 }


### PR DESCRIPTION
#### Purpose

For Operators, some Built-In functions and other functions position of ToolTip don't changes when mouse is move from top to bottom of members list.
#### Modifications

Position of ToolTip is defined in `PlacementCallback` method. Sometimes this method is not called. There was added line

``` C#
this.HorizontalOffset++;
```

This line causes reposition of Popup and as result callback is executed.

Some information can be found [here](http://stackoverflow.com/questions/1600218/how-can-i-move-a-wpf-popup-when-its-anchor-element-moves).
#### Additional references

[MAGN-4662](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4662#).
#### Reviewers

@Benglin, please take a look.
