### PR TITLE
REACH-40 Profile UI speed in Dynamo/Flood

### DIFF
--- a/src/DynamoWebServer/Interfaces/IWebSocket.cs
+++ b/src/DynamoWebServer/Interfaces/IWebSocket.cs
@@ -11,7 +11,7 @@ namespace DynamoWebServer
     {
         bool Setup(IRootConfig rootConfig, IServerConfig serverConfig);
         bool Start();
-        WebSocketSession GetAppSessionByID(string sessionID);
+        WebSocketSession GetAppSessionById(string sessionId);
 
         event Action<WebSocketSession> NewSessionConnected;
         event Action<WebSocketSession, string> NewMessageReceived;

--- a/src/DynamoWebServer/Messages/ConnectorToCreate.cs
+++ b/src/DynamoWebServer/Messages/ConnectorToCreate.cs
@@ -40,11 +40,11 @@ namespace DynamoWebServer.Messages
         [DataMember]
         public int EndPortIndex { get; private set; }
 
-        public ConnectorToCreate(string sNodeID, int sIndex, string eNodeID, int eIndex)
+        public ConnectorToCreate(string sNodeId, int sIndex, string eNodeId, int eIndex)
         {
-            StartNodeId = sNodeID;
+            StartNodeId = sNodeId;
             StartPortIndex = sIndex;
-            EndNodeId = eNodeID;
+            EndNodeId = eNodeId;
             EndPortIndex = eIndex;
         }
 
@@ -55,13 +55,13 @@ namespace DynamoWebServer.Messages
             {
                 foreach (var connector in outPort.Connectors)
                 {
-                    string startID = connector.Start.Owner.GUID.ToString();
+                    string startId = connector.Start.Owner.GUID.ToString();
                     int startIndex = connector.Start.Index;
 
-                    string endID = connector.End.Owner.GUID.ToString();
+                    string endId = connector.End.Owner.GUID.ToString();
                     int endIndex = connector.End.Index;
 
-                    result.Add(new ConnectorToCreate(startID, startIndex, endID, endIndex));
+                    result.Add(new ConnectorToCreate(startId, startIndex, endId, endIndex));
                 }
             }
 

--- a/src/DynamoWebServer/Messages/ExecutedNode.cs
+++ b/src/DynamoWebServer/Messages/ExecutedNode.cs
@@ -14,7 +14,7 @@ namespace DynamoWebServer.Messages
         /// Guid of the specified node
         /// </summary>
         [DataMember]
-        public string NodeID { get; private set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// State of the node after executing
@@ -42,7 +42,7 @@ namespace DynamoWebServer.Messages
 
         public ExecutedNode(NodeModel node, string data)
         {
-            this.NodeID = node.GUID.ToString();
+            this.NodeId = node.GUID.ToString();
             this.State = node.State.ToString();
             this.StateMessage = node.ToolTipText;
             this.Data = data;

--- a/src/DynamoWebServer/Messages/GeometryData.cs
+++ b/src/DynamoWebServer/Messages/GeometryData.cs
@@ -14,7 +14,7 @@ namespace DynamoWebServer.Messages
         /// Guid of the specified node
         /// </summary>
         [DataMember]
-        public string NodeID { get; private set; }
+        public string NodeId { get; private set; }
 
         /// <summary>
         /// List of the graphic primitives that result object consist of.
@@ -25,7 +25,7 @@ namespace DynamoWebServer.Messages
 
         public GeometryData(string id, List<IRenderPackage> packages)
         {
-            this.NodeID = id;
+            this.NodeId = id;
             GeneratePrimitives(packages);
         }
 

--- a/src/DynamoWebServer/Messages/GetNodeGeometryMessage.cs
+++ b/src/DynamoWebServer/Messages/GetNodeGeometryMessage.cs
@@ -8,11 +8,11 @@ namespace DynamoWebServer.Messages
         /// Guid of the specified node
         /// </summary>
         [DataMember]
-        public string NodeID { get; set; }
+        public string NodeId { get; set; }
 
         public GetNodeGeometryMessage(string id)
         {
-            this.NodeID = id;
+            this.NodeId = id;
         }
     }
 }

--- a/src/DynamoWebServer/Responses/NodeCreationDataResponse.cs
+++ b/src/DynamoWebServer/Responses/NodeCreationDataResponse.cs
@@ -5,7 +5,7 @@ namespace DynamoWebServer.Responses
 {
     public class NodeCreationDataResponse : Response
     {
-        public string WorkspaceID { get; set; }
+        public string WorkspaceId { get; set; }
         public IEnumerable<object> Nodes { get; set; }
         public IEnumerable<object> Connections { get; set; }
         public IEnumerable<object> NodesResult { get; set; }

--- a/src/DynamoWebServer/Responses/UpdateProxyNodesResponse.cs
+++ b/src/DynamoWebServer/Responses/UpdateProxyNodesResponse.cs
@@ -17,16 +17,16 @@ namespace DynamoWebServer.Responses
         /// Guid of the workspace that custom nodes belong to.
         /// If it's home workspace the value is empty
         /// </summary>
-        public string WorkspaceID { get; set; }
+        public string WorkspaceId { get; set; }
         
         /// <summary>
         /// Guid of the custom node workspace that was loaded
         /// </summary>
-        public string CustomNodeID { get; set; }
+        public string CustomNodeId { get; set; }
         
         /// <summary>
         /// Guids of nodes that are not proxy anymore
         /// </summary>
-        public IEnumerable<string> NodesIDs { get; set; }
+        public IEnumerable<string> NodesIds { get; set; }
     }
 }

--- a/src/DynamoWebServer/WebServer.cs
+++ b/src/DynamoWebServer/WebServer.cs
@@ -82,7 +82,7 @@ namespace DynamoWebServer
 
         public void SendResponse(Response response, string sessionId)
         {
-            var session = webSocket.GetAppSessionByID(sessionId);
+            var session = webSocket.GetAppSessionById(sessionId);
             if (session != null)
             {
                 session.Send(JsonConvert.SerializeObject(response, jsonSettings));
@@ -124,7 +124,7 @@ namespace DynamoWebServer
                 return;
             }
 
-            messageHandler.Id = session.SessionID;
+            messageHandler.SessionId = session.SessionID;
 
             ExecuteMessageFromSocket(new ClearWorkspaceMessage(), session.SessionID);
             LogInfo("Web socket: connected");

--- a/src/DynamoWebServer/WebSocket.cs
+++ b/src/DynamoWebServer/WebSocket.cs
@@ -34,9 +34,9 @@ namespace DynamoWebServer
             return webSocketServer.Start();
         }
 
-        public WebSocketSession GetAppSessionByID(string sessionID)
+        public WebSocketSession GetAppSessionById(string sessionId)
         {
-            return webSocketServer.GetAppSessionByID(sessionID);
+            return webSocketServer.GetAppSessionByID(sessionId);
         }
 
         void socketServer_NewSessionConnected(WebSocketSession session)


### PR DESCRIPTION
While profiling Flood UI speed we found out that in some cases we got more responses from server than we asked for. This was happening because some times event was not unbound correctly. So in this PR I remove event binding each time RunCancelComand received and now we bind event only once on webserver start.
