### PR TITLE
For Items getter throwing exception replaced to empty collection

### DIFF
--- a/src/DynamoCore/Search/BrowserInternalElement.cs
+++ b/src/DynamoCore/Search/BrowserInternalElement.cs
@@ -232,11 +232,12 @@ namespace Dynamo.Nodes.Search
     {
         #region BrowserItem abstract members implementation
 
+        private ObservableCollection<BrowserItem> items;
         public override ObservableCollection<BrowserItem> Items
         {
             get
             {
-                throw new System.NotImplementedException();
+                return items;
             }
             set
             {
@@ -319,6 +320,8 @@ namespace Dynamo.Nodes.Search
         public ClassInformation()
             : base()
         {
+            items = new ObservableCollection<BrowserItem>();
+
             createMembers = new List<BrowserInternalElement>();
             actionMembers = new List<BrowserInternalElement>();
             queryMembers = new List<BrowserInternalElement>();


### PR DESCRIPTION
#### Purpose

Some methods while going through all Nodes of Tree use `Items` property getting of `ClassInformation`. It throws `NotimplementedException`.
#### Modifications

`Items` Getter returns empty collection.
#### Additional references

[MAGN-4768](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4768).
#### Reviewers

@Benglin, please take a look.
