### PR TITLE
DUI: Empty place appears for StandardPanel if top group is only presented

### DIFF
--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml
@@ -179,6 +179,10 @@
             </ListBox>
             <Border Padding="0,10,0,10"
                     Grid.Row="2">
+                <Border.Visibility>
+                    <Binding Path="IsSecondaryHeaderLeftVisible"
+                             Converter="{StaticResource BoolToVisibilityCollapsedConverter}" />
+                </Border.Visibility>
                 <StackPanel Orientation="Horizontal"
                             Margin="16,0,0,0">
                     <TextBlock x:Name="secondaryHeaderLeft"


### PR DESCRIPTION
# Before

![image](https://cloud.githubusercontent.com/assets/8158404/4543688/6efb4922-4e2d-11e4-930a-a94451c9e283.png)
# After

![image](https://cloud.githubusercontent.com/assets/8158404/4543697/81326e68-4e2d-11e4-9809-5bc74efb5006.png)
# Reviewers

@Benglin, please take a look.

Link to YouTrack:
[MAGN-4950](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4950#) DUI: Empty place appears for StandardPanel if top group is only presented
