### PR TITLE
DUI: toggle button color change for nested classes

### DIFF
--- a/src/DynamoCore/UI/Converters.cs
+++ b/src/DynamoCore/UI/Converters.cs
@@ -1739,7 +1739,7 @@ namespace Dynamo.Controls
 
     // It's used for ClassDetails and ClassObject itself. ClassDetails should be not focusable,
     // in contrast to ClassObject. 
-    public class DataContextToBoolConverter : IValueConverter
+    public class ElementTypeToBoolConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/src/DynamoCore/UI/Views/LibrarySearchView.xaml
+++ b/src/DynamoCore/UI/Views/LibrarySearchView.xaml
@@ -134,7 +134,7 @@
         <!-- Region Converters -->
 
         <!--Converter to Make class details not focusable-->
-        <controls:DataContextToBoolConverter x:Key="DataContextToBoolConverter" />
+        <controls:ElementTypeToBoolConverter x:Key="ElementTypeToBoolConverter" />
         <controls:BrowserRootElementToSubclassesConverter x:Key="BrowserRootElementToSubclassesConverter" />
 
         <!--Converter that will be used, if number of found classes equals 0. 
@@ -497,7 +497,7 @@
                                                 <Setter.Value>
                                                     <Binding RelativeSource="{RelativeSource Self}"
                                                              Path="DataContext"
-                                                             Converter="{StaticResource DataContextToBoolConverter}" />
+                                                             Converter="{StaticResource ElementTypeToBoolConverter}" />
                                                 </Setter.Value>
                                             </Setter>
 

--- a/src/DynamoCore/UI/Views/LibraryView.xaml
+++ b/src/DynamoCore/UI/Views/LibraryView.xaml
@@ -16,7 +16,7 @@
             <!-- Region Converters -->
 
             <!--Converter to Make class details not focusable-->
-            <controls:DataContextToBoolConverter x:Key="DataContextToBoolConverter" />
+            <controls:ElementTypeToBoolConverter x:Key="ElementTypeToBoolConverter" />
             <controls:BrowserRootElementToSubclassesConverter x:Key="BrowserRootElementToSubclassesConverter" />
             <controls:FullyQualifiedNameToDisplayConverter x:Key="FullyQualifiedNameToDisplayConverter" />
             <controls:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
@@ -262,7 +262,7 @@
                                 <Setter.Value>
                                     <Binding RelativeSource="{RelativeSource Self}"
                                              Path="DataContext"
-                                             Converter="{StaticResource DataContextToBoolConverter}" />
+                                             Converter="{StaticResource ElementTypeToBoolConverter}" />
                                 </Setter.Value>
                             </Setter>
 
@@ -562,7 +562,7 @@
                                                     <DataTrigger.Binding>
                                                         <Binding RelativeSource="{RelativeSource Self}"
                                                                  Path="DataContext"
-                                                                 Converter="{StaticResource DataContextToBoolConverter}" />
+                                                                 Converter="{StaticResource ElementTypeToBoolConverter}" />
                                                     </DataTrigger.Binding>
                                                     <Setter Property="Background"
                                                             Value="#2F2F2F" />
@@ -605,7 +605,7 @@
                                             <Condition.Binding>
                                                 <Binding RelativeSource="{RelativeSource Self}"
                                                          Path="DataContext"
-                                                         Converter="{StaticResource DataContextToBoolConverter}" />
+                                                         Converter="{StaticResource ElementTypeToBoolConverter}" />
                                             </Condition.Binding>
                                         </Condition>
                                     </MultiDataTrigger.Conditions>


### PR DESCRIPTION
# Before

![image](https://cloud.githubusercontent.com/assets/8158404/4573414/18214190-4f92-11e4-9aed-190b69166536.png)
# After

![image](https://cloud.githubusercontent.com/assets/8158404/4573398/f2ef4c00-4f91-11e4-8d9e-ab61d0954417.png)
# Solution

Depending on type we choose background of toggle button. If item is `RootElement` Background will be dark grey. If item is `InternalElement` Background will be light grey.
# Reviewers

@Benglin,@vmoyseenko, please take a look.

Tasks on YouTrack:
[MAGN-4966](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4966) DUI: Styling Toggle Button for Nested Category
