### PR TITLE
Check whether node is Regular and then add BIEFC.

### DIFF
--- a/src/DynamoCore/Search/SearchModel.cs
+++ b/src/DynamoCore/Search/SearchModel.cs
@@ -488,6 +488,7 @@ namespace Dynamo.Search
             }
 
             // We sure, that the last member is class.
+            if(nodeType == ElementType.Regular)
             currentCat = TryAddChildClass(currentCat, splitCat[splitCat.Count-1], resourceAssembly);
 
             return currentCat;


### PR DESCRIPTION
# Before

![image](https://cloud.githubusercontent.com/assets/8158404/4574684/d6c41850-4f9e-11e4-9ffd-faab818cd8f2.png)
# After

![image](https://cloud.githubusercontent.com/assets/8158404/4574672/c052f762-4f9e-11e4-8800-b2589bf93d6e.png)
# Solution

We need to add BIEFC only when our node is regular node.
# Reviewers

@Benglin,@vmoyseenko, please take a look.

Tasks on YouTrack:
[MAGN-4986](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4986) DUI: "Dynamo.Nodes.Search.BrowserInternalElementForClasses" appears instead of Addons TreeView node
