### PR TITLE
Show / Hide add-ons header

### DIFF
--- a/src/DynamoCore/UI/Views/LibraryView.xaml
+++ b/src/DynamoCore/UI/Views/LibraryView.xaml
@@ -24,6 +24,7 @@
             <controls:BrowserItemToBooleanConverter x:Key="BrowserItemToBooleanConverter" />
             <!--Depending on the number of points in FullCategoryName margin will be done.-->
             <controls:FullCategoryNameToMarginConverter x:Key="FullCategoryNameToMarginConverter" />
+            <controls:IntToVisibilityConverter x:Key="IntToVisibilityConverter" />
 
             <!--EndRegion-->
 
@@ -498,7 +499,7 @@
                                 </Button.Template>
                                 <Border Name="Bd"
                                         BorderThickness="0"
-                                        BorderBrush="Transparent">                                   
+                                        BorderBrush="Transparent">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
@@ -568,7 +569,7 @@
                                                             Value="#2F2F2F" />
                                                     <Setter Property="Padding"
                                                             Value="0,0,0,10" />
-                                                </DataTrigger>                                               
+                                                </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
                                     </Border.Style>
@@ -774,6 +775,10 @@
                 <Border Grid.Row="1"
                         Background="#353535"
                         Height="27">
+                    <Border.Visibility>
+                        <Binding Path="Model.AddonRootCategories.Count"
+                                 Converter="{StaticResource IntToVisibilityConverter}" />
+                    </Border.Visibility>
                     <TextBlock Text="Add-ons"
                                VerticalAlignment="Center"
                                FontSize="13"


### PR DESCRIPTION
#### Purpose

Implement logic to show / hide add-ons header depending on AddonRootCategories collection element availability.
#### Modifications

Binding to `Visibility` of label is added.
#### Additional references

[MAGN-4644](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4644).
#### Reviewers

@Benglin, this one is really simple. Please, take a look.
