### PR TITLE
DUI: Classes must be always at top of panel

### DIFF
--- a/src/DynamoCore/UI/Commands/BrowserItemCommands.cs
+++ b/src/DynamoCore/UI/Commands/BrowserItemCommands.cs
@@ -21,7 +21,8 @@ namespace Dynamo.Nodes.Search
         {
             this.Items = new ObservableCollection<BrowserItem>(this.Items.OrderBy(x => x.Name));
 
-            // Classes must be always at the top lvl.
+            // BrowserInternalElementForClasses object, if any, must 
+            // always appear before any other nested namespaces. 
             var classes = this.Items.OfType<BrowserInternalElementForClasses>().FirstOrDefault();
             if (classes != null)
             {


### PR DESCRIPTION
So, I found out, that before loading SearchModel it makes sorting of children by name. Luckily, order of BIE and BIEFC was right in standalone application , but not in Revit.
That's why I added case, so that now at the top level application sets only BIEFC, if BIEFC is presented.

Reviewers:
@Benglin, please take a look.
Link to YouTrack:
[MAGN-5016](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5016) DUI: Classes must be always at top of panel with classes and nested categories
