### PR TITLE
DUI: fix appearance of tooltip.

### DIFF
--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml
@@ -28,12 +28,6 @@
 
         <Style x:Key="ListBoxItemStyle"
                TargetType="{x:Type ListBoxItem}">
-            <Setter Property="Background">
-                <Setter.Value>
-                    <Binding Path="IsRootCategoryDetails"
-                             Converter="{StaticResource BooleanToBrushConverter}" />
-                </Setter.Value>
-            </Setter>
             <Setter Property="BorderBrush"
                     Value="Transparent" />
             <Setter Property="BorderThickness"


### PR DESCRIPTION
First, I wanted to mention that, `Background` has been already setted (line 118). So, this `Setter` is excess. Moreover, because of this setter tooltip doesn't appear properly. In my opinion it's because we access to bound property. Well, all in all removing this setter fixes tooltip and this removing doesn't break other functionalities.

Reviewers:
@Benglin, please take a look.
Link to YouTrack:
[MAGN-4866](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4866#) DUI: Hovering over space after the items should tooltip and highlight
