### PR TITLE
DUI: highlighting toggle triangle

### DIFF
--- a/src/DynamoCore/UI/Views/LibraryView.xaml
+++ b/src/DynamoCore/UI/Views/LibraryView.xaml
@@ -299,7 +299,6 @@
             <!-- Used for nested categories. E.g. nodes stucture for Revit root. -->
             <HierarchicalDataTemplate x:Key="NestedCategoryTemplate"
                                       ItemsSource="{Binding Path=Items}">
-                <!--<Border Height="30">-->
                 <TextBlock Foreground="#989898"
                            FontSize="13"
                            Text="{Binding Path=Name}"
@@ -319,7 +318,6 @@
                         </Style>
                     </TextBlock.Style>
                 </TextBlock>
-                <!--</Border>-->
             </HierarchicalDataTemplate>
 
             <!-- Used for categories that is full of memebers without classes. E.g. Operators.-->


### PR DESCRIPTION
We found out, that triangle isn't highlighted only for root categories, that are full of classes. For others(like Operators) everything worked properly. So, I've decided to update xaml styles.

Reviewers
@Benglin,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-5087](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5087) DUI: On hovering category style is not changed for core libraries
