### PR TITLE
CustomNode should be always added to AddonsTreeView

### DIFF
--- a/src/DynamoCore/Search/SearchModel.cs
+++ b/src/DynamoCore/Search/SearchModel.cs
@@ -286,11 +286,7 @@ namespace Dynamo.Search
 
         internal ElementType GetElementType(BrowserInternalElement item)
         {
-            //TODO: Add check if item is loaded as part of package
-            if (item is CustomNodeSearchElement)
-                return ElementType.CustomNode;
-
-            if (item is DSFunctionNodeSearchElement || item is NodeSearchElement)
+            if (item is NodeSearchElement)
                 return (item as NodeSearchElement).ElementType;
 
             return ElementType.Regular;


### PR DESCRIPTION
#### Purpose

In this PR is handled next situation.

User installs package. Package has a node which belongs to core libraries category. Full name: "Core.List.Zip Lists". Now it is added to core category Core.List and break our UI. To avoid it was decided to add node to addons category "Core.List". It will be a different TreeView in UI.
##### Before changes

Package node appears under core library category
![core under regular - part1](https://cloud.githubusercontent.com/assets/8158551/4677515/aa18c918-55e8-11e4-95f0-37d08930bafe.PNG)
![core under regular - part2 - together](https://cloud.githubusercontent.com/assets/8158551/4677530/dd1bee80-55e8-11e4-8c7c-16f7412242fb.png)
##### After changes

Package node appears under addons.
![core under add-ons](https://cloud.githubusercontent.com/assets/8158551/4677537/04d090ca-55e9-11e4-9695-6ad488fd7099.PNG)
#### Modifications

To some functions were added argument `ElementType nodeType`. The main goal is to add node to correct collection: `BrowserRootCategories` or `AddonRootCategories` depending on this parameter.
#### Additional references

This PR should be merged after https://github.com/Benglin/Dynamo/pull/129.

YouTrack task: [MAGN-5088](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5088).
#### Reviewers

@aosyatnik, @Benglin, please, take a look.

Ben, I am thinking is this possible in some why move code connected with categories manipulation in separate class. Instance of class will save such parameters as `resourceAssembly` and `nodeType`. It will not be necessary to pass them in every function. Anyway we should do this refactoring if applicable as separate task.
