### PR TITLE
Remove dotted black rectangle on selected listbox item

### DIFF
--- a/src/DynamoCore/UI/Views/LibrarySearchView.xaml
+++ b/src/DynamoCore/UI/Views/LibrarySearchView.xaml
@@ -258,6 +258,8 @@
                     Value="40" />
             <Setter Property="Background"
                     Value="#333333" />
+            <Setter Property="FocusVisualStyle"
+                    Value="{x:Null}" />
 
             <Setter Property="Template">
                 <Setter.Value>
@@ -553,6 +555,9 @@
                                         </ListView.ItemsPanel>
                                         <ListView.ItemContainerStyle>
                                             <Style TargetType="{x:Type ListViewItem}">
+                                                <Setter Property="FocusVisualStyle"
+                                                        Value="{x:Null}" />
+
                                                 <EventSetter Event="PreviewMouseLeftButtonDown"
                                                              Handler="OnClassButtonCollapse" />
 


### PR DESCRIPTION
#### Purpose

We have next border for selected item in two listboxes. This PR removes it.
![dottedclass](https://cloud.githubusercontent.com/assets/8158551/4704848/95bef156-5875-11e4-88ca-8094c317be1f.PNG)
![dottedmember](https://cloud.githubusercontent.com/assets/8158551/4704847/95bc81d2-5875-11e4-9240-4192705e6489.PNG)
#### Modifications

Add `<Setter Property="FocusVisualStyle" Value="{x:Null}" />` for `ListBoxItem` style.
#### Additional references

[MAGN-5116](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5116).
#### Reviewers

@aosyatnik, @Benglin, please, take a look.
