### PR TITLE
DUI: further optimize icons loading

### DIFF
--- a/src/DynamoCore/Library/LibraryCustomization.cs
+++ b/src/DynamoCore/Library/LibraryCustomization.cs
@@ -111,13 +111,13 @@ namespace Dynamo.DSEngine
 
     public class LibraryCustomization
     {
-        private XDocument xmlDocument;
+        private readonly XDocument xmlDocument;
 
         private Dictionary<string, BitmapSource> cachedIcons = 
             new Dictionary<string, BitmapSource>(StringComparer.OrdinalIgnoreCase);
 
-        private string assemblyName;
-        private Assembly resourceAssembly;
+        private readonly string assemblyName;
+        private readonly Assembly resourceAssembly;
 
         private const string imagesSuffix = "Images";
 


### PR DESCRIPTION
State: _Minor_
# Description

This is from reviewing [this](https://github.com/Benglin/Dynamo/pull/92) pull request. Since LibraryCustomization.resourceAssembly is only ever initialized once for each LibraryCustomization, if it is null the LibraryCustomization.LoadIconInternal should return early.
Also do the following:
1. Rename XmlDocument data member to xmlDocument.
2. Make xmlDocument, assemblyName and resourceAssembly as readonly data members.
# Reviewers

@Benglin ,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-4936](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4936) DUI: Further optimize LibraryCustomization.LoadIconInternal
