### PR TITLE
DUI: typed parameters to string improvement

### DIFF
--- a/src/DynamoCore/Nodes/BaseTypes.cs
+++ b/src/DynamoCore/Nodes/BaseTypes.cs
@@ -144,10 +144,14 @@ namespace Dynamo.Nodes
         }
 
         /// <summary>
-        /// This method returns a name for the icon based on type of this icon.
+        /// This method returns a name for the icon based on name of the node.
         /// </summary>
-        /// <param name="descriptor"></param>
-        /// <returns></returns>
+        /// <param name="descriptor">Function descriptor, that contains all info about node.</param>
+        /// <param name="overridePrefix">
+        /// overridePrefix is used as default value for generating node icon name.
+        /// If overridePrefix is empty, it uses QualifiedName property.
+        /// e.g. Autodesk.DesignScript.Geometry.CoordinateSystem.ByOrigin
+        /// </param>
         public static string TypedParametersToString(FunctionDescriptor descriptor, string overridePrefix = "")
         {
             var builder = new StringBuilder();

--- a/src/DynamoCore/Search/SearchElements/DSFunctionNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/DSFunctionNodeSearchElement.cs
@@ -74,11 +74,11 @@ namespace Dynamo.Search.SearchElements
                     {
                         return Utils.TypedParametersToString(FunctionDescriptor);
                     }
-                    // Case for nodes which have in name forbidden symbols e.g. %, <, >, etc.
-                    // Should be used FunctionDescriptor.Name property instead.
-                    // For example: we have DynamoUnits.SUnit.%, but we want to have DynamoUnits.SUnit.mod
                     else
                     {
+                        // Some nodes contain names with invalid symbols like %, <, >, etc. In this 
+                        // case the value of "FunctionDescriptor.Name" property should be used. For 
+                        // an example, "DynamoUnits.SUnit.%" to be renamed as "DynamoUnits.SUnit.mod".
                         string shortName = Nodes.Utilities.NormalizeAsResourceName(FunctionDescriptor.Name);
                         return Utils.TypedParametersToString(FunctionDescriptor, name + shortName);
                     }


### PR DESCRIPTION
State: _Minor_
# Description

This is taken from [this](https://github.com/Benglin/Dynamo/pull/91) pull request. The current implementation `Utilities.TypedParametersToString` method could use some improvements.

Method signatureThe signature should have been:

``` c#
public static string TypedParametersToString(FunctionDescriptor descriptor,
    string overridePrefix = string.Empty)
{
    // ...
}
```

Overriding name prefixThe method body should use the `overridePrefix` if one is supplied, or fallback to use `NormalizeAsResourceName` if none is supplied:

``` c#
public static string TypedParametersToString(...)
{
    // If the caller does not supply a prefix, use default logic to generate one.
    if (string.IsNullOrEmpty(overridePrefix))
        overridePrefix = NormalizeAsResourceName(FunctionDescriptor.QualifiedName);

    return overridePrefix + '''.''' + builder.ToString();
}
```

DocumentationThe following comment should be moved to one of the callers (choose a caller that is having the issue of names with invalid symbols):

``` c#
// Case for nodes which have in name forbidden symbols e.g. %, <, >, etc.
// Should be used FunctionDescriptor.Name property instead.
// For example: we have DynamoUnits.SUnit.%, but we want to have DynamoUnits.SUnit.mod
```
# Reviewers

@Benglin ,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-4956](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4956) DUI: Improve TypedParametersToString utility method
