### PR TITLE
DUI: Highlight ClassButton when it got focus

### DIFF
--- a/src/DynamoCore/UI/Views/LibrarySearchView.xaml
+++ b/src/DynamoCore/UI/Views/LibrarySearchView.xaml
@@ -631,6 +631,18 @@
                                                                     Value="#404040" />
                                                         </MultiTrigger.Setters>
                                                     </MultiTrigger>
+                                                    <MultiTrigger>
+                                                        <MultiTrigger.Conditions>
+                                                            <Condition Property="IsSelected"
+                                                                       Value="False" />
+                                                            <Condition Property="IsFocused"
+                                                                       Value="True" />
+                                                        </MultiTrigger.Conditions>
+                                                        <MultiTrigger.Setters>
+                                                            <Setter Property="Background"
+                                                                    Value="#404040" />
+                                                        </MultiTrigger.Setters>
+                                                    </MultiTrigger>
                                                 </Style.Triggers>
                                             </Style>
                                         </ListView.ItemContainerStyle>


### PR DESCRIPTION
When class button got focus, its' background became the same color as, when mouse is over it.

Reviewers
@Benglin ,@vmoyseenko, please take a look.
