### PR TITLE
Top Result header is returned

### DIFF
--- a/src/DynamoCore/UI/Views/LibrarySearchView.xaml
+++ b/src/DynamoCore/UI/Views/LibrarySearchView.xaml
@@ -515,7 +515,7 @@
                     <StackPanel.Visibility>
                         <Binding Converter="{StaticResource NullValueToCollapsedConverter}" />
                     </StackPanel.Visibility>
-                    <TextBlock Text="{Binding Name}"
+                    <TextBlock Text="{Binding FullyQualifiedName}"
                                Margin="16,8,0,8"
                                Foreground="#989898"
                                FontSize="12" />


### PR DESCRIPTION
Hi @Benglin, simple change for Top Result category which fixes next situation:
![image](https://cloud.githubusercontent.com/assets/8158551/4808804/09531bc6-5ea5-11e4-8c3c-0fcfd4ea0ba0.png)

Please, take a look.
