### PR TITLE
DUI: left right arrow crashes dynamo

### DIFF
--- a/src/DynamoCore/UI/LibraryWrapPanel.cs
+++ b/src/DynamoCore/UI/LibraryWrapPanel.cs
@@ -57,9 +57,9 @@ namespace Dynamo.Controls
             var listButtons = buttonsWrapPanel.Children;
 
             // If focused element is NodeSearchElement, that means focused element is inside expanded class.
-            // If user presses Up, we have to move back to selected class.
             if (classButton.DataContext is NodeSearchElement)
             {
+                // If user presses Up, we have to move back to selected class.
                 if (e.Key == Key.Up)
                 {
                     var selectedClassButton = listButtons.OfType<ListViewItem>().
@@ -68,6 +68,7 @@ namespace Dynamo.Controls
                     e.Handled = true;
                     return;
                 }
+                // Otherwise, let user move inside expanded class.
                 return;
             }
 


### PR DESCRIPTION
Preface
When focus is on member button and this button is longer than `LibraryView`, if user presses left or right button it crashes Dynamo.
Solution
We need to check first: are we inside class details or not. And only than count new index, if this is needed.

Reviewers
@Benglin ,@vmoyseenko, please take a look.
