### PR TITLE
DUI: remove key navigation from library view.

### DIFF
--- a/src/DynamoCore/UI/Views/LibraryView.xaml
+++ b/src/DynamoCore/UI/Views/LibraryView.xaml
@@ -224,7 +224,8 @@
                           ScrollViewer.VerticalScrollBarVisibility="Hidden"
                           ScrollViewer.CanContentScroll="False"
                           ScrollViewer.IsDeferredScrollingEnabled="False"
-                          ItemsSource="{Binding Path=Items}">
+                          ItemsSource="{Binding Path=Items}"
+                          PreviewKeyDown="OnSubCategoryListViewPreviewKeyDown">
                     <ListView.ItemsPanel>
                         <ItemsPanelTemplate>
                             <controls:LibraryWrapPanel Background="Transparent"

--- a/src/DynamoCore/UI/Views/LibraryView.xaml.cs
+++ b/src/DynamoCore/UI/Views/LibraryView.xaml.cs
@@ -56,5 +56,10 @@ namespace Dynamo.UI.Views
             if (buttons != null)
                 buttons.UnselectAll();
         }
+
+        private void OnSubCategoryListViewPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            e.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
Priority: _Critical_
Suddenly, I found out, that LibraryView should not have any navigation. So, I created `PreviewKeyDown` to handle key down.

Reviewers
@Benglin ,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-5241](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5241) DUI: Disable navigation for regular view
