### PR TITLE
StandardPanel with Queries only doesn't have a header

### DIFF
--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml.cs
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml.cs
@@ -130,6 +130,8 @@ namespace Dynamo.UI.Controls
 
             castedDataContext.CurrentDisplayMode = ClassInformation.DisplayMode.None;
 
+            castedDataContext.IsMoreButtonVisible = false;
+
             // Case when CreateMembers list is not empty.
             // We should present CreateMembers in primaryMembers.            
             if (hasCreateMembers)
@@ -186,6 +188,7 @@ namespace Dynamo.UI.Controls
             // If QueryMembers is not empty the list will be presented in primaryMembers. 
             if (hasQueryMembers)
             {
+                castedDataContext.IsPrimaryHeaderVisible = true;
                 castedDataContext.PrimaryHeaderText = QueryHeaderText;
                 primaryMembers.ItemsSource = castedDataContext.QueryMembers;
             }
@@ -265,7 +268,7 @@ namespace Dynamo.UI.Controls
 
             // We are at the first member of secondary members, 
             // we have to move to last member of primary members.
-            if (secondaryMembers.Items.Contains(focusedButtonContent) )
+            if (secondaryMembers.Items.Contains(focusedButtonContent))
             {
                 var generator = primaryMembers.ItemContainerGenerator;
                 (generator.ContainerFromIndex(primaryMembers.Items.Count - 1) as ListBoxItem).Focus();


### PR DESCRIPTION
#### Purpose

For some cases `StandardPanel` doesn't have header. "More" button is available but no more methods panel has.
![image](https://cloud.githubusercontent.com/assets/8158551/4850619/3daaca8c-606b-11e4-9991-c6d9438b1945.png)
#### Additional references

For more information how to reproduce go to [MAGN-5243](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5243).
#### Reviewers

@aosyatnik, @Benglin, please, take a look.
