### PR TITLE
Bread crumbs are fixed

### DIFF
--- a/src/DynamoCore/Search/SearchMemberGroup.cs
+++ b/src/DynamoCore/Search/SearchMemberGroup.cs
@@ -17,6 +17,9 @@ namespace Dynamo.Search
         {
             get
             {
+                if (string.IsNullOrEmpty(FullyQualifiedName))
+                    return string.Empty;
+
                 var delimiter = string.Format(" {0} ", Configurations.ShortenedCategoryDelimiter);
 
                 int index = FullyQualifiedName.IndexOf(delimiter);

--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AstBuilderTest.cs" />
+    <Compile Include="SearchMemberGroupTests.cs" />
     <Compile Include="TypedParametersToStringTests.cs" />
     <Compile Include="CodeBlockNodeTests.cs" />
     <Compile Include="CustomNodeWorkspaceOpening.cs" />

--- a/test/DynamoCoreTests/SearchMemberGroupTests.cs
+++ b/test/DynamoCoreTests/SearchMemberGroupTests.cs
@@ -1,0 +1,35 @@
+﻿using Dynamo.Search;
+using Dynamo.UI;
+using NUnit.Framework;
+
+namespace Dynamo.Tests
+{
+    [TestFixture]
+    class SearchMemberGroupTests
+    {
+        [Test]
+        [Category("UnitTests")]
+        public void PrefixTest()
+        {
+            var memberGroup = new SearchMemberGroup(null);
+            Assert.AreEqual(string.Empty, memberGroup.Prefix);
+
+            memberGroup = new SearchMemberGroup(string.Empty);
+            Assert.AreEqual(string.Empty, memberGroup.Prefix);
+
+            var delimiter = string.Format(" {0} ", Configurations.ShortenedCategoryDelimiter);
+            var fullyQualifiedName = "Builtin Functions" + delimiter + "Actions";
+
+            memberGroup = new SearchMemberGroup(fullyQualifiedName);
+            Assert.AreEqual(string.Empty, memberGroup.Prefix);
+
+            fullyQualifiedName = "1stCategory" + delimiter +
+                                 "2ndCategory" + delimiter +
+                                 "3rdCategory" + delimiter + "Create";
+
+            memberGroup = new SearchMemberGroup(fullyQualifiedName);
+            Assert.AreEqual("2ndCategory" + delimiter +
+                            "3rdCategory" + delimiter, memberGroup.Prefix);
+        }
+    }
+}


### PR DESCRIPTION
#### Purpose

Remove top category from bread crumbs. Image to understand what the PR resolves.
![removetopcategoryfrombc](https://cloud.githubusercontent.com/assets/8158551/4884520/86f6eb90-636c-11e4-879e-0244985f102e.PNG)
#### Modifications

Modified logic of `SearchMemberGroup.Prefix` property to remove top category from it.
#### Additional references

[MAGN-5225](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5225).
#### Unit tests

Created new test function `SearchMemberGroupTests.PrefixTest`.
![image](https://cloud.githubusercontent.com/assets/8158551/4896708/1db15e08-63fe-11e4-8439-abe79b2e3f0e.png)
#### Reviewers

@aosyatnik, @Benglin, please, take a look.
