### PR TITLE
REACH-82 "Null value cannot be cast to double"

### DIFF
--- a/src/DynamoWebServer/Program.cs
+++ b/src/DynamoWebServer/Program.cs
@@ -28,6 +28,13 @@ namespace DynamoWebServer
                     Preferences = PreferenceSettings.Load()
                 });
 
+            var viewModel = DynamoViewModel.Start(
+                new DynamoViewModel.StartConfiguration()
+                {
+                    CommandFilePath = null,
+                    DynamoModel = model
+                });
+
             var webSocketServer = new WebServer(model, new WebSocket());
 
             webSocketServer.Start();
@@ -41,13 +48,6 @@ namespace DynamoWebServer
             }
             else
             {
-                var viewModel = DynamoViewModel.Start(
-                new DynamoViewModel.StartConfiguration()
-                {
-                    CommandFilePath = null,
-                    DynamoModel = model
-                });
-
                 var view = new DynamoView(viewModel);
                 app.Run(view);
             }


### PR DESCRIPTION
When Number node is created it has `Value` is `null`. And only rendering causes updating it to `"0"`. Or changing `Value` from "0" to another number. That's why in headless mode when we created node number without changing its value (we need exactly "0") and connect it with another node, running is failed because that other node needs number rather than `null`
