### PR TITLE
DUI: Fix cursor appearing for start of search

### DIFF
--- a/src/DynamoCore/UI/Views/LibraryContainerView.xaml
+++ b/src/DynamoCore/UI/Views/LibraryContainerView.xaml
@@ -212,7 +212,8 @@
                            Grid.Row="2"
                            VerticalAlignment="Stretch"
                            HorizontalAlignment="Stretch"
-                           DataContext="{Binding}">
+                           DataContext="{Binding}"
+                           PreviewKeyDown="OnLibraryViewPreviewKeyDown">
             <views:LibraryView.Visibility>
                 <Binding Path="CurrentMode"
                          Converter="{StaticResource ViewModeToVisibilityConverter}"
@@ -222,7 +223,8 @@
 
         <!-- LIBRARYSEARCH VIEW -->
         <views:LibrarySearchView Grid.Row="2"
-                                 DataContext="{Binding}">
+                                 DataContext="{Binding}"
+                                 PreviewKeyDown="OnLibraryViewPreviewKeyDown">
             <views:LibrarySearchView.Visibility>
                 <Binding Path="CurrentMode"
                          Converter="{StaticResource ViewModeToVisibilityConverter}"

--- a/src/DynamoCore/UI/Views/LibraryContainerView.xaml.cs
+++ b/src/DynamoCore/UI/Views/LibraryContainerView.xaml.cs
@@ -336,5 +336,11 @@ namespace Dynamo.Search
             var topResult = WPF.FindChild<ListBox>(this, "topResultListBox");
             if ((topResult != null) && (topResult.IsFocused)) SearchTextBox.Focus();
         }
+
+        private void OnLibraryViewPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Escape) return;
+            SearchTextBox.Text = "";
+        }
     }
 }


### PR DESCRIPTION
Cursor should blink before "Search" label.

Before
![image](https://cloud.githubusercontent.com/assets/8158404/4897416/0eb95ff6-6406-11e4-9ccf-98511191a9cb.png)

After
![image](https://cloud.githubusercontent.com/assets/8158404/4897810/abd866d0-6409-11e4-9bfe-561c027a5a97.png)

Reviewers
@Benglin ,@vmoyseenko, please take a look.
Link to YouTrack:
[MAGN-5271](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5271) DUI: Fix cursor appearing for start of search
