### PR TITLE
DUI: improve search member group name.

### DIFF
--- a/src/DynamoCore/Search/SearchMemberGroup.cs
+++ b/src/DynamoCore/Search/SearchMemberGroup.cs
@@ -20,13 +20,10 @@ namespace Dynamo.Search
                 if (string.IsNullOrEmpty(FullyQualifiedName))
                     return string.Empty;
 
-                var delimiter = string.Format(" {0} ", Configurations.ShortenedCategoryDelimiter);
-
                 int index = FullyQualifiedName.IndexOf(delimiter);
                 var name = index > -1 ? FullyQualifiedName.Substring(index + delimiter.Length)
                                       : FullyQualifiedName;
 
-                // Skip past the last delimiter and get the group name.
                 index = name.LastIndexOf(delimiter);
                 return index > -1 ? name.Substring(0, index + delimiter.Length)
                                   : string.Empty;
@@ -37,8 +34,10 @@ namespace Dynamo.Search
         {
             get
             {
-                int startIndexOfGroupType = FullyQualifiedName.LastIndexOf(Configurations.ShortenedCategoryDelimiter) + 2;
-                return FullyQualifiedName.Substring(startIndexOfGroupType);
+                // Skip past the last delimiter and get the group name.
+                int index = FullyQualifiedName.LastIndexOf(delimiter);
+                return index > -1 ? FullyQualifiedName.Substring(index + delimiter.Length)
+                                  : string.Empty;
             }
         }
 
@@ -63,6 +62,7 @@ namespace Dynamo.Search
         }
 
         private bool showAllMembers = false;
+        private string delimiter = string.Format(" {0} ", Configurations.ShortenedCategoryDelimiter);
 
         internal SearchMemberGroup(string fullyQualifiedName)
         {

--- a/src/DynamoCore/UI/Views/LibrarySearchView.xaml
+++ b/src/DynamoCore/UI/Views/LibrarySearchView.xaml
@@ -684,16 +684,14 @@
                                         <ListBox.ItemTemplate>
                                             <DataTemplate>
                                                 <StackPanel MouseLeftButtonDown="OnMemberGroupNameMouseDown">
-                                                    <WrapPanel Orientation="Horizontal"
+                                                    <TextBlock Foreground="#989898"
+                                                               FontSize="12"
                                                                Margin="16,8,0,8">
-                                                        <TextBlock Text="{Binding Prefix}"
-                                                                   Foreground="#989898"
-                                                                   FontSize="12"
-                                                                   MouseLeftButtonDown="OnPrefixTextBlockMouseDown" />
-                                                        <TextBlock Text="{Binding GroupName}"
-                                                                   FontSize="12">
-                                                            <TextBlock.Style>
-                                                                <Style TargetType="{x:Type TextBlock}">
+                                                            <Run Text="{Binding Prefix, Mode=OneWay}"
+                                                                 MouseDown="OnPrefixTextBlockMouseDown" />
+                                                            <Run Text="{Binding GroupName, Mode=OneWay}">
+                                                                <Run.Style>
+                                                                   <Style TargetType="{x:Type Run}">
                                                                     <Setter Property="Foreground"
                                                                             Value="#989898" />
                                                                     <Style.Triggers>
@@ -703,10 +701,10 @@
                                                                                     Value="#aaaaaa" />
                                                                         </Trigger>
                                                                     </Style.Triggers>
-                                                                </Style>
-                                                            </TextBlock.Style>
-                                                        </TextBlock>
-                                                    </WrapPanel>
+                                                                </Style> 
+                                                                </Run.Style>
+                                                            </Run>
+                                                    </TextBlock>
                                                     <ListBox Background="Transparent"
                                                              BorderBrush="Transparent"
                                                              ItemContainerStyle="{DynamicResource ListBoxMembersStyle}"

--- a/src/DynamoCore/UI/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCore/UI/Views/LibrarySearchView.xaml.cs
@@ -100,7 +100,7 @@ namespace Dynamo.UI.Views
 
         private void OnMemberGroupNameMouseDown(object sender, MouseButtonEventArgs e)
         {
-            if (!(e.OriginalSource is TextBlock)) return;
+            if (!(e.OriginalSource is System.Windows.Documents.Run)) return;
 
             var memberGroup = sender as FrameworkElement;
             var memberGroupContext = memberGroup.DataContext as SearchMemberGroup;
@@ -109,7 +109,7 @@ namespace Dynamo.UI.Views
             memberGroupContext.ExpandAllMembers();
 
             // Make textblock underlined.
-            var textBlock = e.OriginalSource as TextBlock;
+            var textBlock = e.OriginalSource as System.Windows.Documents.Run;
             textBlock.TextDecorations = TextDecorations.Underline;
         }
 


### PR DESCRIPTION
# Description

This is created for a [previous pull request](https://github.com/Benglin/Dynamo/pull/139).

Please refer to [this article](http://msdn.microsoft.com/en-us/library/bb613560%28v=vs.110%29.aspx) on MSDN and look under the section Avoid Using **TextBlock** in FlowDocument, then we know using **Run** element is better than having multiple **TextBlock** in terms of performance (I know the performance is not an issue for this case, but I'd prefer to have the right implementation). We should merge **SearchMemberGroup.Prefix** and **SearchMemberGroup.Name** into a single property that returns **Run objects** for **TextBlock.Content**.

Also, the last few comments in the same pull request for Prefix and GroupName should be fixed along with this.
# NB

Sorry, I couldn't get what you mean in this sentence: We should merge **SearchMemberGroup.Prefix** and **SearchMemberGroup.Name** into a single property that returns Run objects for TextBlock.Content. Could you, please, clarify it once more, so that I could add changes in this PR?
# Reviewers

@Benglin ,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-5178](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5178) DUI: Improve SearchMemberGroup Name Display
