### PR TITLE
StandardPanel bugs fixing

### DIFF
--- a/src/DynamoCore/UI/Controls/StandardPanel.xaml
+++ b/src/DynamoCore/UI/Controls/StandardPanel.xaml
@@ -114,11 +114,11 @@
             </Style.Triggers>
         </Style>
     </UserControl.Resources>
+    <UserControl.Visibility>
+        <Binding Path="ClassDetailsVisibility"
+                 Converter="{StaticResource BoolToVisibilityCollapsedConverter}" />
+    </UserControl.Visibility>
     <Border Padding="0,10,0,10">
-        <Border.Visibility>
-            <Binding Path="ClassDetailsVisibility"
-                     Converter="{StaticResource BoolToVisibilityCollapsedConverter}" />
-        </Border.Visibility>
         <Border.Background>
             <Binding Path="IsRootCategoryDetails"
                      Converter="{StaticResource BooleanToBrushConverter}" />

--- a/src/DynamoCore/UI/LibraryWrapPanel.cs
+++ b/src/DynamoCore/UI/LibraryWrapPanel.cs
@@ -294,7 +294,7 @@ namespace Dynamo.Controls
             classInformation.PopulateMemberCollections(currentClass as BrowserInternalElement);
 
             // When we know the number of items on a single row, through selected 
-            // item index we will find out where the expanded StandardPanel sit.  
+            // item index we will find out where the expanded StandardPanel sit.
             var itemsPerRow = ((int)Math.Floor(ActualWidth / classObjectWidth));
             var d = ((double)selectedClassProspectiveIndex) / itemsPerRow;
             var selectedItemRow = ((int)Math.Floor(d));


### PR DESCRIPTION
#### Purpose

Fix bug with resizing of `StandardPanel`.
Fix bug with empty place when resizing to 5 items.
#### Modifications

Hidden `StandardPanel` shouldn't be arranged in `LibraryWrapPanel.ArrangeOverride`.
Change `ClassDetailsVisibility` binding to `StandardPanel` UserControl.
#### Additional references

[MAGN-5345](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5345).
[MAGN-5378](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5378).
#### Reviewers

@aosyatnik, @Benglin, please, take a look.
