### PR TITLE
REACH-102 Port default behavior not correct

### DIFF
--- a/src/DynamoCore/Models/NodeModel.cs
+++ b/src/DynamoCore/Models/NodeModel.cs
@@ -1354,6 +1354,19 @@ namespace Dynamo.Models
                 return true;
             }
 
+            if (name == "UsingDefault" )
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    return true;
+
+                var arr = value.Split(';');
+                for (int i = 0; i < arr.Length; i ++)
+                {
+                    InPorts[i].UsingDefaultValue = !bool.Parse(arr[i]);
+                }
+                return true;
+            }
+
             return base.UpdateValueCore(name, value);
         }
 

--- a/src/DynamoCore/Search/SearchElements/SearchElementBase.cs
+++ b/src/DynamoCore/Search/SearchElements/SearchElementBase.cs
@@ -127,7 +127,10 @@ namespace Dynamo.Search.SearchElements
 
         [DataMember]
         public IEnumerable<string> ReturnKeys { get; private set; }
-        
+
+        [DataMember]
+        public IEnumerable<object> DefaultValues { get; private set; }
+
         public LibraryItem(SearchElementBase node, DynamoModel dynamoModel)
         {
             Category = node.FullCategoryName;
@@ -178,11 +181,13 @@ namespace Dynamo.Search.SearchElements
             {
                 Parameters = newElement.InPorts.Select(elem => elem.PortName);
                 ReturnKeys = newElement.OutPorts.Select(elem => elem.PortName);
+                DefaultValues = newElement.InPortData.Select(elem => elem.DefaultValue);
             }
             else
             {
                 Parameters = new[] { "Input" };
                 ReturnKeys = new[] { "Output" };
+                DefaultValues = new object[0];
             }
         }
     }


### PR DESCRIPTION
The information about node ports default values obtained from the Dynamo node sended to the Flood. Updated data from the Flood changes values in the Dynamo.
