### PR TITLE
[DNM] DUI: Addons refresh icon. Part 1

### DIFF
--- a/src/DynamoCore/PackageManager/PackageManagerClient.cs
+++ b/src/DynamoCore/PackageManager/PackageManagerClient.cs
@@ -113,12 +113,11 @@ namespace Dynamo.PackageManager
 
         #endregion
 
-        private static readonly string serverUrl = "https://www.dynamopackages.com/";
 
         public PackageManagerClient(DynamoModel dynamoModel)
         {
             this.dynamoModel = dynamoModel;
-            Client = new Client(null, serverUrl); 
+            Client = new Client(null, Dynamo.UI.Configurations.ServerUrl); 
         }
 
         //public bool IsNewestVersion(string packageId, string currentVersion, ref string newerVersion )

--- a/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
+++ b/src/DynamoCore/Search/SearchElements/CustomNodeSearchElement.cs
@@ -13,9 +13,8 @@ namespace Dynamo.Search.SearchElements
 {
     public class CustomNodeSearchElement : NodeSearchElement, IEquatable<CustomNodeSearchElement>
     {
-        private static readonly string serverUrl = "https://www.dynamopackages.com/";
         private XmlDocument xmlDoc = new XmlDocument();
-        private Client client = new Client(null, serverUrl);
+        private Client client = new Client(null, Dynamo.UI.Configurations.ServerUrl);
 
         public Guid Guid { get; internal set; }
 

--- a/src/DynamoCore/UI/Configurations.cs
+++ b/src/DynamoCore/UI/Configurations.cs
@@ -14,6 +14,7 @@ namespace Dynamo.UI
         public static readonly double IntegerSliderTextBoxWidth = 30.0;
         public static readonly double MaxWatchNodeWidth = 280.0;
         public static readonly double MaxWatchNodeHeight = 310.0;
+        public static readonly string ServerUrl = "https://www.dynamopackages.com/";
 
         #endregion
 


### PR DESCRIPTION
Priority: _Minor_
To `CustomNodeSearchElement` added 2 properties: `CurrentVersion` and `LastVersion`.
Current is loaded from XML-file.
Last is loaded from server.
In next PR I will compare them to show Refresh icon.

Reviewers
@Benglin ,@vmoyseenko, please take a look.

Link to YouTrack:
[MAGN-5401](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5401) DUI: Add version property to Custom Node to make decision about displaying of refresh icon