### PR TITLE
Opening a file issue

### DIFF
--- a/src/DynamoWebServer/Messages/FileUploader.cs
+++ b/src/DynamoWebServer/Messages/FileUploader.cs
@@ -26,27 +26,28 @@ namespace DynamoWebServer.Messages
             connectorsToCreate = new List<ConnectorToCreate>();
         }
 
-        internal ProcessResult ProcessFileData(UploadFileMessage uploadFileMessage, DynamoModel dynamoViewModel)
+        internal ProcessResult ProcessFileData(UploadFileMessage uploadFileMessage, DynamoModel dynamoModel)
         {
             try
             {
-                IsCustomNode = uploadFileMessage.IsCustomNode;
                 var result = ProcessResult.Succeeded;
 
                 // if path was specified it means NWK is used
                 if (!string.IsNullOrEmpty(uploadFileMessage.Path))
                 {
-                    dynamoViewModel.ExecuteCommand(new DynamoModel.OpenFileCommand(uploadFileMessage.Path));
+                    dynamoModel.ExecuteCommand(new DynamoModel.OpenFileCommand(uploadFileMessage.Path));
                     result = ProcessResult.RespondWithPath;
+                    IsCustomNode = dynamoModel.CurrentWorkspace is CustomNodeWorkspaceModel;
                 }
                 else
                 {
+                    IsCustomNode = uploadFileMessage.IsCustomNode;
                     var content = uploadFileMessage.FileContent;
                     var filePath = Path.GetTempPath() + "\\" + uploadFileMessage.FileName;
                     
                     File.WriteAllBytes(filePath, content);
 
-                    dynamoViewModel.ExecuteCommand(new DynamoModel.OpenFileCommand(filePath));
+                    dynamoModel.ExecuteCommand(new DynamoModel.OpenFileCommand(filePath));
 
                     File.Delete(filePath);
                 }

--- a/src/DynamoWebServer/Messages/UploadFileMessage.cs
+++ b/src/DynamoWebServer/Messages/UploadFileMessage.cs
@@ -80,6 +80,7 @@ namespace DynamoWebServer.Messages
                 topNode = xmlDoc.GetElementsByTagName("dynWorkspace");
             }
 
+            bool hasID = false;
             // find workspace name
             foreach (XmlNode node in topNode)
             {
@@ -88,10 +89,11 @@ namespace DynamoWebServer.Messages
                     if (att.Name.Equals("Name"))
                         name = att.Value;
                     else if (att.Name.Equals("ID"))
-                        IsCustomNode = !string.IsNullOrEmpty(att.Value);
+                        hasID = !string.IsNullOrEmpty(att.Value);
                 }
             }
 
+            IsCustomNode = hasID || name != "Home";
             if (!IsCustomNode)
                 return "Home.dyn";
             else


### PR DESCRIPTION
It's possible a user tries to upload a file with `.dyn` or `.dyf` extension but it doesn't correspond to its content (a file with `dyn` extension but actually it's a custom node and v.v.). Therefore we can't relay on the file path when define the type. So define the type of workspace from the file content
