### PR TITLE
Changed minimum width of sidebar to include 2 classes

### DIFF
--- a/src/DynamoCore/UI/Configurations.cs
+++ b/src/DynamoCore/UI/Configurations.cs
@@ -213,7 +213,7 @@ namespace Dynamo.UI
 
         #region LibraryView
 
-        public const double MinWidthLibraryView = 308;
+        public const double MinWidthLibraryView = 204;
 
         public const string TopResult = "Top Result";
         public const string CategoryGroupCreate = "Create";

--- a/src/DynamoCore/UI/Views/DynamoView.xaml
+++ b/src/DynamoCore/UI/Views/DynamoView.xaml
@@ -173,7 +173,7 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"
                               MaxWidth="500"
-                              MinWidth="308"
+                              MinWidth="204"
                               Name="LibraryViewColumn"/>
             <!--MinWidth fix for GridSplitter dragging in frameless window-->
             <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
#### Purpose

Reduce minimum width of Library sidebar to include 2 classes instead of 3.
#### Modifications

Changed width value. Screenshot of result:
![image](https://cloud.githubusercontent.com/assets/8158551/5204303/f0003330-7596-11e4-83c1-c2c7695e5ea0.png)
#### Additional references

[MAGN-5528](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5528).
#### Reviewers

@ramramps, please, take a look.

@Benglin, FYI.
