### PR TITLE
"SEARCH" is renamed to "SEARCH LIBRARY"

### DIFF
--- a/src/DynamoCore/UI/Views/LibraryContainerView.xaml
+++ b/src/DynamoCore/UI/Views/LibraryContainerView.xaml
@@ -136,15 +136,14 @@
                     <TextBlock Name="SearchTextBlock"
                                FontSize="14"
                                IsHitTestVisible="False"
-                               Foreground="#878787"
+                               Foreground="#AAAAAA"
                                VerticalAlignment="Center"
                                Visibility="{Binding Path=SearchText, 
                                                     Converter={StaticResource NonEmptyStringToCollapsedConverter}}"
                                HorizontalAlignment="Center"
                                Height="18"
-                               Width="52"
                                Margin="3,0,0,0">
-                        SEARCH
+                        SEARCH LIBRARY
                     </TextBlock>
                 </StackPanel>
 


### PR DESCRIPTION
#### Purpose
1. Change search text hint from `SEARCH` to `SEARCH LIBRARY`.
2. Change this label normal font color to `#AAAAAA`.
#### Modifications
##### Before

![image](https://cloud.githubusercontent.com/assets/8158551/5259937/cc51468a-7a10-11e4-9c30-6c582d283897.png)
##### After

![image](https://cloud.githubusercontent.com/assets/8158551/5259991/9712d992-7a11-11e4-9568-6516c35f6274.png)
#### Additional references

[MAGN-5571](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5571).
#### Reviewers

@ramramps, please, take a look.
@Benglin, FYI.
