### PR TITLE
Don't use workspace's own filename during saving

### DIFF
--- a/src/DynamoWebServer/Messages/MessageHandler.cs
+++ b/src/DynamoWebServer/Messages/MessageHandler.cs
@@ -278,6 +278,9 @@ namespace DynamoWebServer.Messages
                     OnResultReady(this, new ResultReadyEventArgs(
                         new SavedFileResponse(fileName, fileContent), sessionId));
                 }
+
+                // reset file path
+                workspaceToSave.FileName = null;
             }
             catch
             {


### PR DESCRIPTION
Example when current behavior is incorrect:
- create custom node tab in Flood, set its `Name` to "Custom node 1";
- save this ws into a file - the ws will be saved with "Custom node 1" `Name` that is correct;
- change the workspace `Name` to "Custom node 2";
- save this ws into a file again - the ws will be saved with "Custom node 1" `Name` that is incorrect.

The ws has wrong `Name` because previous saving set `FileName` to "Custom node 1.dyf". Next saving uses this `FileName` and overrides `Name` according to it ("Custom node 2" -> "Custom node 1")
