### PR TITLE
Remove superfluous parameter dynamo

### DIFF
--- a/src/DynamoWebServer/WebServer.cs
+++ b/src/DynamoWebServer/WebServer.cs
@@ -196,11 +196,11 @@ namespace DynamoWebServer
         {
             if (enqueue)
             {
-                messageQueue.EnqueueMessage(() => messageHandler.Execute(dynamoModel, message, sessionId));
+                messageQueue.EnqueueMessage(() => messageHandler.Execute(message, sessionId));
             }
             else
             {
-                messageHandler.Execute(dynamoModel, message, sessionId);
+                messageHandler.Execute(message, sessionId);
             }
         }
 

--- a/test/Server/SocketTest/SocketTests.cs
+++ b/test/Server/SocketTest/SocketTests.cs
@@ -182,7 +182,7 @@ namespace Dynamo.Tests
             };
 
             Message message = messageHandler.DeserializeMessage(createCommand);
-            messageHandler.Execute(Model, message, "");
+            messageHandler.Execute(message, "");
 
             var resultPath = Path.Combine(GetTestDirectory(), @"core\commands\codeBlockExpectedResult.txt");
             var expectedResult = File.ReadAllText(resultPath);


### PR DESCRIPTION
`WebServer` passes `dynamoModel` parameter to `MessageHandler.Execute` method but `MessageHandler` has already got `dynamoModel` instance during the creation
