### PR TITLE
Children should be collapsed during expanding of parent

### DIFF
--- a/src/DynamoCore/UI/Commands/BrowserItemCommands.cs
+++ b/src/DynamoCore/UI/Commands/BrowserItemCommands.cs
@@ -186,8 +186,10 @@ namespace Dynamo.Nodes.Search
 
                     // Collapse all expanded items on next level.
                     if (endState)
+                    {
                         foreach (var ele in element.Items)
                             ele.IsExpanded = false;
+                    }
 
                     foreach (var ele in element.Siblings)
                         ele.IsExpanded = false;


### PR DESCRIPTION
#### Purpose

After opening of namespaces all subnamespaces and StandardPanel should be closed, no any class selected.

Example 
We got next view. `Core.File` namespace is expanded. `Core.Types` class expanded.
![image](https://cloud.githubusercontent.com/assets/8158551/5359441/158e022e-7fc6-11e4-9b65-9ea4d1a550fc.png)

if you reopen `Core` (click double on category) you should get this view
![image](https://cloud.githubusercontent.com/assets/8158551/5359482/6f489798-7fc6-11e4-9fa7-f12bb4908334.png)
#### Modifications

Added collapsing of next level items in `ToggleIsExpanded` command.
#### Additional references

[MAGN-5619](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5619).
#### Reviewers

@Benglin, please, take a look.
