### PR TITLE
Left sidebar width should be restored when Dynamo loads

### DIFF
--- a/src/DynamoCore/Core/PreferenceSettings.cs
+++ b/src/DynamoCore/Core/PreferenceSettings.cs
@@ -10,7 +10,6 @@ using DynamoUnits;
 
 using DynamoUtilities;
 
-
 namespace Dynamo
 {
     /// <summary>
@@ -22,7 +21,7 @@ namespace Dynamo
     public class PreferenceSettings : NotificationObject, IPreferences
     {
         public static string DYNAMO_TEST_PATH = null;
-        const string DYNAMO_SETTINGS_FILE = "DynamoSettings.xml";
+        private const string DYNAMO_SETTINGS_FILE = "DynamoSettings.xml";
         private LengthUnit _lengthUnit;
         private AreaUnit _areaUnit;
         private VolumeUnit _volumeUnit;
@@ -37,6 +36,7 @@ namespace Dynamo
         public bool IsAnalyticsReportingApproved { get; set; }
         #endregion
 
+        public int LeftSidebarWidth { get; set; }
         public int ConsoleHeight { get; set; }
         public bool ShowConnector { get; set; }
         public ConnectorType ConnectorType { get; set; }
@@ -113,7 +113,7 @@ namespace Dynamo
                 }
                 else
                 {
-                    lastUpdateDownloadPath = value; 
+                    lastUpdateDownloadPath = value;
                 }
             }
         }
@@ -128,6 +128,7 @@ namespace Dynamo
             // Default Settings
             IsFirstRun = true;
             IsUsageReportingApproved = false;
+            LeftSidebarWidth = 304;
             ConsoleHeight = 0;
             ShowConnector = true;
             ConnectorType = ConnectorType.BEZIER;
@@ -150,7 +151,7 @@ namespace Dynamo
         {
             try
             {
-                var serializer = new XmlSerializer(typeof (PreferenceSettings));
+                var serializer = new XmlSerializer(typeof(PreferenceSettings));
                 using (var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write))
                 {
                     serializer.Serialize(fs, this);
@@ -163,7 +164,7 @@ namespace Dynamo
                 Console.WriteLine(ex.Message);
                 Console.WriteLine(ex.StackTrace);
             }
-            
+
             return false;
         }
 
@@ -173,7 +174,7 @@ namespace Dynamo
         /// <returns>Whether file is saved or error occurred.</returns>
         public bool Save()
         {
-            if ( DYNAMO_TEST_PATH == null )
+            if (DYNAMO_TEST_PATH == null)
                 // Save in User Directory Path
                 return Save(GetSettingsFilePath());
             else
@@ -207,10 +208,10 @@ namespace Dynamo
                 }
             }
             catch (Exception) { }
-            
+
             return settings;
         }
-        
+
         /// <summary>
         /// Return PreferenceSettings from Default XML path
         /// </summary>
@@ -220,7 +221,7 @@ namespace Dynamo
         /// </returns>
         public static PreferenceSettings Load()
         {
-            if ( DYNAMO_TEST_PATH == null )
+            if (DYNAMO_TEST_PATH == null)
                 // Save in User Directory Path
                 return Load(GetSettingsFilePath());
             else

--- a/src/DynamoCore/Core/PreferenceSettings.cs
+++ b/src/DynamoCore/Core/PreferenceSettings.cs
@@ -36,7 +36,7 @@ namespace Dynamo
         public bool IsAnalyticsReportingApproved { get; set; }
         #endregion
 
-        public int LeftSidebarWidth { get; set; }
+        public int LibraryWidth { get; set; }
         public int ConsoleHeight { get; set; }
         public bool ShowConnector { get; set; }
         public ConnectorType ConnectorType { get; set; }
@@ -128,7 +128,7 @@ namespace Dynamo
             // Default Settings
             IsFirstRun = true;
             IsUsageReportingApproved = false;
-            LeftSidebarWidth = 304;
+            LibraryWidth = 304;
             ConsoleHeight = 0;
             ShowConnector = true;
             ConnectorType = ConnectorType.BEZIER;

--- a/src/DynamoCoreWpf/ViewModels/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/DynamoViewModel.cs
@@ -273,16 +273,16 @@ namespace Dynamo.ViewModels
             }
         }
 
-        public int LeftSidebarWidth
+        public int LibraryWidth
         {
             get
             {
-                return model.PreferenceSettings.LeftSidebarWidth;
+                return model.PreferenceSettings.LibraryWidth;
             }
             set
             {
-                model.PreferenceSettings.LeftSidebarWidth = value;
-                RaisePropertyChanged("LeftSidebarWidth");
+                model.PreferenceSettings.LibraryWidth = value;
+                RaisePropertyChanged("LibraryWidth");
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/DynamoViewModel.cs
@@ -273,6 +273,19 @@ namespace Dynamo.ViewModels
             }
         }
 
+        public int LeftSidebarWidth
+        {
+            get
+            {
+                return model.PreferenceSettings.LeftSidebarWidth;
+            }
+            set
+            {
+                model.PreferenceSettings.LeftSidebarWidth = value;
+                RaisePropertyChanged("LeftSidebarWidth");
+            }
+        }
+
         public bool IsShowingConnectors
         {
             get

--- a/src/DynamoCoreWpf/Views/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/DynamoView.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Dynamo.Views"
-        xmlns:sys="clr-namespace:System;assembly=mscorlib" 
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:models="clr-namespace:Dynamo.Models;assembly=DynamoCore"
         xmlns:controls="clr-namespace:Dynamo.Controls"
         xmlns:uictrls="clr-namespace:Dynamo.UI.Controls"
@@ -173,10 +173,15 @@
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*"
-                              MaxWidth="500"
+            <ColumnDefinition MaxWidth="500"
                               MinWidth="204"
-                              Name="LibraryViewColumn" />
+                              Name="LibraryViewColumn">
+                <ColumnDefinition.Width>
+                    <Binding Path="LeftSidebarWidth"
+                             Mode="TwoWay"
+                             Converter="{StaticResource ConsoleHeightConverter}" />
+                </ColumnDefinition.Width>
+            </ColumnDefinition>
             <!--MinWidth fix for GridSplitter dragging in frameless window-->
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="5*" />
@@ -228,7 +233,9 @@
                                   InputGestureText="Ctrl + O"
                                   Focusable="False">
                             <MenuItem.Icon>
-                                <Image Source="/DynamoCoreWpf;component/UI/Images/openHS.png" Width="14" Height="14" />
+                                <Image Source="/DynamoCoreWpf;component/UI/Images/openHS.png"
+                                       Width="14"
+                                       Height="14" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <Separator />
@@ -238,7 +245,9 @@
                                   InputGestureText="Ctrl + S"
                                   Focusable="False">
                             <MenuItem.Icon>
-                                <Image Source="/DynamoCoreWpf;component/UI/Images/saveHS.png" Width="14" Height="14" />
+                                <Image Source="/DynamoCoreWpf;component/UI/Images/saveHS.png"
+                                       Width="14"
+                                       Height="14" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <MenuItem Focusable="False"
@@ -247,7 +256,9 @@
                                   Name="saveButton"
                                   InputGestureText="Ctrl + Shift + S">
                             <MenuItem.Icon>
-                                <Image Source="/DynamoCoreWpf;component/UI/Images/saveHS.png" Width="14" Height="14" />
+                                <Image Source="/DynamoCoreWpf;component/UI/Images/saveHS.png"
+                                       Width="14"
+                                       Height="14" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <Separator />
@@ -261,7 +272,9 @@
                                   Command="{Binding ShowSaveImageDialogAndSaveResultCommand}"
                                   Name="saveImage">
                             <MenuItem.Icon>
-                                <Image Source="/DynamoCoreWpf;component/UI/Images/screenshot_normal.png" Width="14" Height="14"/>
+                                <Image Source="/DynamoCoreWpf;component/UI/Images/screenshot_normal.png"
+                                       Width="14"
+                                       Height="14" />
                             </MenuItem.Icon>
                         </MenuItem>
                         <MenuItem Focusable="False"
@@ -1650,7 +1663,7 @@
                       Background="#999"
                       Cursor="/DynamoCoreWpf;component/UI/Images/resize_vertical.cur" />
 
-            <GridSplitter ResizeDirection="Auto"
+        <GridSplitter ResizeDirection="Auto"
                       Grid.Column="1"
                       Grid.Row="2"
                       Grid.RowSpan="2"
@@ -1663,7 +1676,7 @@
                       Background="Transparent"
                       Cursor="/DynamoCoreWpf;component/UI/Images/resize_horizontal.cur" />
 
-            <ItemsControl Name="startPageItemsControl"
+        <ItemsControl Name="startPageItemsControl"
                       Grid.Row="2"
                       Grid.RowSpan="4"
                       Grid.Column="0"

--- a/src/DynamoCoreWpf/Views/DynamoView.xaml
+++ b/src/DynamoCoreWpf/Views/DynamoView.xaml
@@ -177,7 +177,7 @@
                               MinWidth="204"
                               Name="LibraryViewColumn">
                 <ColumnDefinition.Width>
-                    <Binding Path="LeftSidebarWidth"
+                    <Binding Path="LibraryWidth"
                              Mode="TwoWay"
                              Converter="{StaticResource ConsoleHeightConverter}" />
                 </ColumnDefinition.Width>


### PR DESCRIPTION
#### Purpose

Width of sidebar with `LibraryView` should be saved when Dynamo closed and restored when Dynamo started.

#### Modifications

Added property `PreferenceSettings.LeftSidebarWidth` to save / load width.

#### Additional references

[MAGN-5721](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5721) DUI: Left sidebar width should be restored when Dynamo loads

#### Reviewers

@Benglin, please, take a look.