### PR TITLE
Search results navigation interaction correction

### DIFF
--- a/src/DynamoCoreWpf/Views/LibraryContainerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibraryContainerView.xaml.cs
@@ -79,6 +79,8 @@ namespace Dynamo.Search
 
             this.viewModel.RequestFocusSearch += OnSearchViewModelRequestFocusSearch;
             this.viewModel.RequestReturnFocusToSearch += OnSearchViewModelRequestReturnFocusToSearch;
+
+            this.librarySearchView.SearchTextBox = SearchTextBox;
         }
 
         private void OnSearchViewMouseLeave(object sender, MouseEventArgs e)

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml
@@ -573,8 +573,8 @@
                                       OverridesDefaultStyle="True"
                                       Template="{StaticResource CategoryExpanderTemplate}"
                                       IsExpanded="True"
-                                      Expanded="OnCategoryExpanderCollapseExpand"
-                                      Collapsed="OnCategoryExpanderCollapseExpand">
+                                      Expanded="OnCategoryExpanderExpanded"
+                                      Collapsed="OnCategoryExpanderCollapsed">
                                 <StackPanel Orientation="Vertical"
                                             KeyDown="OnCategoryContentKeyDown">
 

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml
@@ -572,7 +572,9 @@
                             <Expander Header="{Binding Path=Name}"
                                       OverridesDefaultStyle="True"
                                       Template="{StaticResource CategoryExpanderTemplate}"
-                                      IsExpanded="True">
+                                      IsExpanded="True"
+                                      Expanded="OnCategoryExpanderCollapseExpand"
+                                      Collapsed="OnCategoryExpanderCollapseExpand">
                                 <StackPanel Orientation="Vertical"
                                             KeyDown="OnCategoryContentKeyDown">
 

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml
@@ -269,6 +269,11 @@
                          Handler="OnMouseLeftButtonDown" />
 
             <Style.Triggers>
+                <Trigger Property="IsMouseOver"
+                         Value="True">
+                    <Setter Property="Background"
+                            Value="#404040" />
+                </Trigger>
                 <Trigger Property="IsSelected"
                          Value="True">
                     <Setter Property="Background"
@@ -534,6 +539,8 @@
                              ScrollViewer.HorizontalScrollBarVisibility="Hidden"
                              ItemsSource="{Binding Members,NotifyOnTargetUpdated=True}"
                              KeyDown="OnMemberButtonKeyDown"
+                             MouseEnter="OnTopResultMouseEnter"
+                             MouseLeave="OnTopResultMouseLeave"
                              TargetUpdated="OnTopResultTargetUpdated">
                         <ListBox.ItemTemplate>
                             <DataTemplate>

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
@@ -575,7 +575,7 @@ namespace Dynamo.UI.Views
             e.Handled = true;
         }
 
-        private ListBoxItem GetVisibleCategory(ListBox parent, int startIndex, Key key)
+        private static ListBoxItem GetVisibleCategory(ListBox parent, int startIndex, Key key)
         {
             if (parent.Equals(null)) return null;
 
@@ -627,6 +627,8 @@ namespace Dynamo.UI.Views
             topResultListBox.ItemContainerGenerator.StatusChanged += OnTopResultListBoxIcgStatusChanged;
         }
 
+        // ListBox.ItemContainerGenerator works asynchronously. To make sure it is ready for use
+        // we check status of it. If status is correct HighlightedItem updated. 
         private void OnTopResultListBoxIcgStatusChanged(object sender, EventArgs e)
         {
             if (topResultListBox.ItemContainerGenerator.Status == GeneratorStatus.ContainersGenerated)
@@ -642,17 +644,21 @@ namespace Dynamo.UI.Views
 
         #endregion
 
+        // As soon as user hover on TopResult HighlightedIten should be updated to it.
         private void OnTopResultMouseEnter(object sender, MouseEventArgs e)
         {
             UpdateHighlightedItem(GetListItemByIndex(topResultListBox, 0));
         }
 
+        // As soon as user goes out of TopResult HighlightedIten should set to null
+        // because nothing is selected.
         private void OnTopResultMouseLeave(object sender, MouseEventArgs e)
         {
             UpdateHighlightedItem(null);
             libraryToolTipPopup.SetDataContext(null);
         }
 
+        // User collapsed a category. Function checks if HighlightedItem inside and deselect it.
         private void OnCategoryExpanderCollapsed(object sender, RoutedEventArgs e)
         {
             SearchTextBox.Focus();

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
@@ -200,7 +200,10 @@ namespace Dynamo.UI.Views
             PresentationSource target;
             // For the first time set top result as HighlightedItem. 
             if (HighlightedItem == null)
+            {
+                UpdateHighlightedItem(GetListItemByIndex(topResultListBox, 0));
                 HighlightedItem = GetSelectedListBoxItem(topResultListBox);
+            }
             if (HighlightedItem == null) return;
 
             target = PresentationSource.FromVisual(HighlightedItem);

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
@@ -530,6 +530,12 @@ namespace Dynamo.UI.Views
             // that means we have to move to first class/method button.
             if (e.Key == Key.Down)
             {
+                if (topResultListBox.IsMouseOver)
+                {
+                    e.Handled = true;
+                    return;
+                }
+
                 //Unselect top result.
                 if (e.OriginalSource is ListBox)
                     (e.OriginalSource as ListBox).UnselectAll();
@@ -605,13 +611,12 @@ namespace Dynamo.UI.Views
             if ((DataContext as SearchViewModel).CurrentMode !=
                 Dynamo.ViewModels.SearchViewModel.ViewMode.LibrarySearchView)
             {
-                libraryToolTipPopup.DataContext = null;
+                libraryToolTipPopup.SetDataContext(null, true);
                 UpdateHighlightedItem(null);
                 return;
             }
             if (sender is ListBox)
             {
-                var topResultListBox = sender as ListBox;
                 topResultListBox.SelectedIndex = 0;
                 libraryToolTipPopup.PlacementTarget = topResultListBox;
                 libraryToolTipPopup.SetDataContext(topResultListBox.SelectedItem);
@@ -620,5 +625,17 @@ namespace Dynamo.UI.Views
 
         #endregion
 
+        private void OnTopResultMouseEnter(object sender, MouseEventArgs e)
+        {
+            UpdateHighlightedItem(GetListItemByIndex(topResultListBox, 0));
+            libraryToolTipPopup.PlacementTarget = topResultListBox;
+            libraryToolTipPopup.SetDataContext(topResultListBox.SelectedItem);
+        }
+
+        private void OnTopResultMouseLeave(object sender, MouseEventArgs e)
+        {
+            (sender as ListBox).UnselectAll();
+            libraryToolTipPopup.SetDataContext(null);
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
@@ -208,7 +208,6 @@ namespace Dynamo.UI.Views
             if (HighlightedItem == null)
             {
                 UpdateHighlightedItem(GetListItemByIndex(topResultListBox, 0));
-                HighlightedItem = GetSelectedListBoxItem(topResultListBox);
             }
             if (HighlightedItem == null) return;
 
@@ -395,7 +394,7 @@ namespace Dynamo.UI.Views
 
                 // Otherwise user pressed down, we have to move to first member button.
                 var memberGroupsListBox = WpfUtilities.ChildOfType<ListBox>(searchCategoryElement, "MemberGroupsListBox");
-                var listItem = FindFirstChildListItem(memberGroupsListBox, "MembersListBox");
+                var listItem = FindChildListItemByIndex(memberGroupsListBox, "MembersListBox");
                 if (listItem != null)
                 {
                     UpdateHighlightedItem(listItem);
@@ -408,7 +407,7 @@ namespace Dynamo.UI.Views
 
         private ListBoxItem FindFirstVisibleCategory(FrameworkElement librarySearchViewElement)
         {
-            var firstCategory = FindFirstChildListItem(librarySearchViewElement, "CategoryListView");
+            var firstCategory = FindChildListItemByIndex(librarySearchViewElement, "CategoryListView");
 
             int index = 1;
             while (firstCategory != null &&
@@ -421,18 +420,10 @@ namespace Dynamo.UI.Views
             return firstCategory;
         }
 
-        private ListBoxItem FindFirstChildListItem(FrameworkElement parent, string listName)
+        private ListBoxItem FindChildListItemByIndex(FrameworkElement parent, string listName, int index = 0)
         {
             var list = WpfUtilities.ChildOfType<ListBox>(parent, listName);
             var generator = list.ItemContainerGenerator;
-            return generator.ContainerFromIndex(0) as ListBoxItem;
-        }
-
-        private ListBoxItem FindChildListItemByIndex(FrameworkElement parent, string listName, int index)
-        {
-            var list = WpfUtilities.ChildOfType<ListBox>(parent, listName);
-            var generator = list.ItemContainerGenerator;
-
             if (0 <= index && index < list.Items.Count)
                 return generator.ContainerFromIndex(index) as ListBoxItem;
             else
@@ -520,8 +511,8 @@ namespace Dynamo.UI.Views
                 }
 #else
                 // If there are no classes, then focus on first method.
-                var memberGroupsList = FindFirstChildListItem(nextSelectedCategory, "MemberGroupsListBox");
-                UpdateHighlightedItem(FindFirstChildListItem(memberGroupsList, "MembersListBox"));
+                var memberGroupsList = FindChildListItemByIndex(nextSelectedCategory, "MemberGroupsListBox");
+                UpdateHighlightedItem(FindChildListItemByIndex(memberGroupsList, "MembersListBox"));
 #endif
             }
             e.Handled = true;
@@ -573,12 +564,12 @@ namespace Dynamo.UI.Views
                 }
 #endif
                 // Otherwise, set selection on the first method button.
-                var firstMemberGroup = FindFirstChildListItem(firstCategory, "MemberGroupsListBox");
-                UpdateHighlightedItem(FindFirstChildListItem(firstMemberGroup, "MembersListBox"));
+                var firstMemberGroup = FindChildListItemByIndex(firstCategory, "MemberGroupsListBox");
+                UpdateHighlightedItem(FindChildListItemByIndex(firstMemberGroup, "MembersListBox"));
             }
             else // Otherwise, Up was pressed. So, we have to move to top result.
             {
-                UpdateHighlightedItem(FindFirstChildListItem(this, "topResultListBox"));
+                UpdateHighlightedItem(FindChildListItemByIndex(this, "topResultListBox"));
             }
 
             e.Handled = true;

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
@@ -390,11 +390,36 @@ namespace Dynamo.UI.Views
             }
         }
 
+        private ListBoxItem FindFirstVisibleCategory(FrameworkElement librarySearchViewElement)
+        {
+            var firstCategory = FindFirstChildListItem(librarySearchViewElement, "CategoryListView");
+
+            int index = 1;
+            while (firstCategory != null &&
+                !WpfUtilities.ChildOfType<Expander>(firstCategory, string.Empty).IsExpanded)
+            {
+                firstCategory = FindChildListItemByIndex(librarySearchViewElement, "CategoryListView", index);
+            }
+
+            return firstCategory;
+        }
+
         private ListBoxItem FindFirstChildListItem(FrameworkElement parent, string listName)
         {
             var list = WpfUtilities.ChildOfType<ListBox>(parent, listName);
             var generator = list.ItemContainerGenerator;
             return generator.ContainerFromIndex(0) as ListBoxItem;
+        }
+
+        private ListBoxItem FindChildListItemByIndex(FrameworkElement parent, string listName, int index)
+        {
+            var list = WpfUtilities.ChildOfType<ListBox>(parent, listName);
+            var generator = list.ItemContainerGenerator;
+
+            if (index < list.Items.Count)
+                return generator.ContainerFromIndex(index) as ListBoxItem;
+            else
+                return null;
         }
 
         /// <summary>
@@ -503,7 +528,12 @@ namespace Dynamo.UI.Views
                 if (e.OriginalSource is ListBox)
                     (e.OriginalSource as ListBox).UnselectAll();
 
-                var firstCategory = FindFirstChildListItem(librarySearchViewElement, "CategoryListView");
+                var firstCategory = FindFirstVisibleCategory(librarySearchViewElement);
+                if (firstCategory == null)
+                {
+                    e.Handled = true;
+                    return;
+                }
 #if SEARCH_SHOW_CLASSES
                 var firstCategoryContent = firstCategory.Content as SearchCategory;
                 // If classes presented, set focus on the first class button.

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
@@ -16,6 +16,8 @@ namespace Dynamo.UI.Views
     {
         private ListBoxItem HighlightedItem;
 
+        public UIElement SearchTextBox;
+
         public LibrarySearchView()
         {
             InitializeComponent();
@@ -639,6 +641,11 @@ namespace Dynamo.UI.Views
         {
             UpdateHighlightedItem(null);
             libraryToolTipPopup.SetDataContext(null);
+        }
+
+        private void OnCategoryExpanderCollapseExpand(object sender, RoutedEventArgs e)
+        {
+            SearchTextBox.Focus();
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
@@ -634,7 +634,7 @@ namespace Dynamo.UI.Views
 
         private void OnTopResultMouseLeave(object sender, MouseEventArgs e)
         {
-            (sender as ListBox).UnselectAll();
+            UpdateHighlightedItem(null);
             libraryToolTipPopup.SetDataContext(null);
         }
     }


### PR DESCRIPTION
#### Purpose

Fix small but not comfortable issues in search results navigation.

#### Modifications

Debug. Some hours of debug. As result some places were improved.

Were added functions to find next or previous *visible* category.

#### Additional references

For the most serious issues were created next tasks:

* [MAGN-5722](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5722) DUI: Do not navigate for closed category members
* [MAGN-5723](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5723) DUI: Navigation should start from TopResult if nothing selected 
* [MAGN-5724](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5724) DUI: If selected member is in just closed category, next arrow button should start navigation from TopResult 

#### Reviewers

@Benglin, please, take a look.