### PR TITLE
[DNM] Show next 5 members when last member is partially visible

### DIFF
--- a/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
@@ -116,16 +116,16 @@ namespace Dynamo.Utilities
             }
         }
 
-        public static bool IsControlUserVisible(FrameworkElement element, FrameworkElement container)
+        public static bool IsControlUserVisible(FrameworkElement element, FrameworkElement container, bool ignoreWidth = false)
         {
             if (!element.IsVisible)
                 return false;
-            //var container = VisualTreeHelper.GetParent(element) as FrameworkElement;
-            //if (container == null) throw new ArgumentNullException("container");
 
-            Rect bounds = element.TransformToAncestor(container).TransformBounds(new Rect(0.0, 0.0, element.RenderSize.Width, element.RenderSize.Height));
+            Rect bounds = element.TransformToAncestor(container).TransformBounds(
+                new Rect(0.0, 0.0, ignoreWidth ? 0 : element.ActualWidth, element.ActualHeight));
             Rect rect = new Rect(0.0, 0.0, container.ActualWidth, container.ActualHeight);
-            return rect.IntersectsWith(bounds);
+
+            return rect.Contains(bounds);
         }
     }
 }

--- a/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
+++ b/src/DynamoCoreWpf/Utilities/WpfUtilities.cs
@@ -115,5 +115,17 @@ namespace Dynamo.Utilities
                 }
             }
         }
+
+        public static bool IsControlUserVisible(FrameworkElement element, FrameworkElement container)
+        {
+            if (!element.IsVisible)
+                return false;
+            //var container = VisualTreeHelper.GetParent(element) as FrameworkElement;
+            //if (container == null) throw new ArgumentNullException("container");
+
+            Rect bounds = element.TransformToAncestor(container).TransformBounds(new Rect(0.0, 0.0, element.RenderSize.Width, element.RenderSize.Height));
+            Rect rect = new Rect(0.0, 0.0, container.ActualWidth, container.ActualHeight);
+            return rect.IntersectsWith(bounds);
+        }
     }
 }

--- a/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/LibrarySearchView.xaml.cs
@@ -187,6 +187,8 @@ namespace Dynamo.UI.Views
             {
                 (HighlightedItem as ListBoxItem).IsSelected = true;
                 ShowTooltip(HighlightedItem as ListBoxItem);
+
+                WpfUtilities.IsControlUserVisible(HighlightedItem, ScrollLibraryViewer);
             }
         }
 


### PR DESCRIPTION
#### Purpose

`LibrarySearchView` should be scrolled if user navigates by keyboard to the most bottom member. Should be shown next 5 members.

#### Modifications

Proposed new function which defines coordinates of currently highlighted member and calculates coordinates of last visible item. Using `ListviewItem.BringIntoView()` item is made visible to user.

#### Additional references

[MAGN-5725](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5725) DUI: Down arrow button on latest visible member should scroll down for next 5 members.

This PR implements scrolling down. Scrolling up can be implemented as new PR or as part of it PR. Anyway this PR should be merged after https://github.com/Benglin/Dynamo/pull/251.

#### Reviewers

@Benglin, please, take a look. 