### PR TITLE
New node addition to nodes tree should fix classes structure

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1909,6 +1909,7 @@ namespace Dynamo.Controls
             if (string.IsNullOrEmpty(incomingString))
                 throw new ArgumentException("value string should not be empty.");
 
+
             var numberOfPoints = incomingString.Count(x => x == Configurations.CategoryDelimiter);
             if (numberOfPoints == 0)
                 return new Thickness(5, 0, 0, 0);
@@ -2039,5 +2040,5 @@ namespace Dynamo.Controls
         {
             throw new NotImplementedException();
         }
-    }        
+    }
 }

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1898,8 +1898,8 @@ namespace Dynamo.Controls
     }
 
     // Depending on the number of points in FullCategoryName margin will be done.
-    // E.g. Geometry.Tesselation -> Margin="10,0,0,0"
-    // E.g. RootCategory.Namespace1.Namespace2 -> Margin="20,0,0,0"
+    // E.g. Geometry -> Margin="5,0,0,0"
+    // E.g. RootCategory.Namespace1.Namespace2 -> Margin="45,0,20,0"
     public class FullCategoryNameToMarginConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -1908,7 +1908,6 @@ namespace Dynamo.Controls
 
             if (string.IsNullOrEmpty(incomingString))
                 throw new ArgumentException("value string should not be empty.");
-
 
             var numberOfPoints = incomingString.Count(x => x == Configurations.CategoryDelimiter);
             if (numberOfPoints == 0)

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -512,8 +512,13 @@ namespace Dynamo.Wpf.ViewModels
 
     public class ClassesNodeCategoryViewModel : NodeCategoryViewModel
     {
-        public NodeCategoryViewModel Parent { get; set; }
+        public NodeCategoryViewModel Parent { get; private set; }
 
-        public ClassesNodeCategoryViewModel() : base("") { }
+        public ClassesNodeCategoryViewModel(string fullCategoryName, NodeCategoryViewModel parent)
+            : base("")
+        {
+            FullCategoryName = fullCategoryName;
+            Parent = parent;
+        }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -514,10 +514,10 @@ namespace Dynamo.Wpf.ViewModels
     {
         public NodeCategoryViewModel Parent { get; private set; }
 
-        public ClassesNodeCategoryViewModel(string fullCategoryName, NodeCategoryViewModel parent)
+        public ClassesNodeCategoryViewModel(NodeCategoryViewModel parent)
             : base("")
         {
-            FullCategoryName = fullCategoryName;
+            FullCategoryName = Configurations.ClassesDefaultName;
             Parent = parent;
         }
     }

--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -512,6 +512,8 @@ namespace Dynamo.Wpf.ViewModels
 
     public class ClassesNodeCategoryViewModel : NodeCategoryViewModel
     {
+        public NodeCategoryViewModel Parent { get; set; }
+
         public ClassesNodeCategoryViewModel() : base("") { }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -332,7 +332,17 @@ namespace Dynamo.ViewModels
             {
                 var next = nameStack.Pop();
                 var categories = target.SubCategories;
-                var newTarget = categories.FirstOrDefault(c => c.Name == next);
+                NodeCategoryViewModel targetClassSuccessor = null;
+                var newTarget = categories.FirstOrDefault(c =>
+                {
+                    if (c is ClassesNodeCategoryViewModel)
+                    {
+                        targetClassSuccessor = c.SubCategories.FirstOrDefault(c2 => c2.Name == next);
+                        return targetClassSuccessor != null;
+                    }
+
+                    return c.Name == next;
+                });
                 if (newTarget == default(NodeCategoryViewModel))
                 {
                     newTarget = isRoot ? new RootNodeCategoryViewModel(next) : new NodeCategoryViewModel(next);
@@ -340,7 +350,10 @@ namespace Dynamo.ViewModels
                     PlaceInNewCategory(entry, newTarget, nameStack);
                     return;
                 }
-                target = newTarget;
+                if (targetClassSuccessor != null)
+                    target = targetClassSuccessor;
+                else
+                    target = newTarget;
                 isRoot = false;
             }
             target.Entries.Add(entry);
@@ -350,8 +363,11 @@ namespace Dynamo.ViewModels
             NodeSearchElementViewModel entry, NodeCategoryViewModel target,
             IEnumerable<string> categoryNames)
         {
-            var newTargets =
-                categoryNames.Select(name => new NodeCategoryViewModel(name));
+            //var path = "";
+            var newTargets = categoryNames.Select(name => new NodeCategoryViewModel(name)).ToList();
+
+            int indexToInsertClass = newTargets.Count - 1 > 0 ? newTargets.Count - 1 : 0;
+            newTargets.Insert(indexToInsertClass, new ClassesNodeCategoryViewModel());
 
             foreach (var newTarget in newTargets)
             {

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -445,8 +445,20 @@ namespace Dynamo.ViewModels
                 return cat;
             }).ToList();
 
-            // Last category in path is class. Should be created and inserted to collection 
-            // classes container ClassesNodeCategoryViewModel
+            // The last entry 'NodeCategoryViewModel' represents a class. For our example the 
+            // entries in 'newTargets' are:
+            // 
+            //      NodeCategoryViewModel("MyAssembly.MyNamespace")
+            //      NodeCategoryViewModel("MyAssembly.MyNamespace.MyClass")
+            // 
+            // Since all class entries are contained under a 'ClassesNodeCategoryViewModel', 
+            // we need to create a new 'ClassesNodeCategoryViewModel' instance, and insert it 
+            // right before the class entry itself to get the following list:
+            // 
+            //      NodeCategoryViewModel("MyAssembly.MyNamespace")
+            //      ClassesNodeCategoryViewModel("Classes")
+            //      NodeCategoryViewModel("MyAssembly.MyNamespace.MyClass")
+            // 
             int indexToInsertClass = newTargets.Count - 1;
             var classParent = indexToInsertClass > 0 ? newTargets[indexToInsertClass - 1] : target;
             var newClass = new ClassesNodeCategoryViewModel(classParent);

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -325,6 +325,14 @@ namespace Dynamo.ViewModels
             }
         }
 
+        /// <summary>
+        /// Insert a new search element under the category.
+        /// </summary>
+        /// <param name="entry">This could represent a function of a given 
+        /// class. For example, 'MyAssembly.MyNamespace.MyClass.Foo'.</param>
+        /// <param name="categoryNames">A list of entries that make up the fully qualified
+        /// class name that contains function 'Foo', e.g. 'MyAssembly.MyNamespace.MyClass'.
+        /// </param>
         private void InsertEntry(NodeSearchElementViewModel entry, IEnumerable<string> categoryNames)
         {
             var nameStack = new Stack<string>(categoryNames.Reverse());

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -270,9 +270,7 @@ namespace Dynamo.ViewModels
 
                 InsertClassesIntoTree(item.SubCategories);
 
-                var container = new ClassesNodeCategoryViewModel();
-                container.Parent = item;
-                container.FullCategoryName = Configurations.ClassesDefaultName;
+                var container = new ClassesNodeCategoryViewModel(Configurations.ClassesDefaultName, item);
                 container.SubCategories.AddRange(classes);
 
                 item.SubCategories.Insert(0, container);
@@ -375,9 +373,8 @@ namespace Dynamo.ViewModels
 
                         if (nameStack.Count == 0)
                         {
-                            targetClass = new ClassesNodeCategoryViewModel();
-                            targetClass.FullCategoryName = Configurations.ClassesDefaultName;
-                            targetClass.Parent = target;
+                            targetClass =
+                                new ClassesNodeCategoryViewModel(Configurations.ClassesDefaultName, target);
 
                             target.SubCategories.Add(targetClass);
                             target = targetClass;
@@ -418,9 +415,9 @@ namespace Dynamo.ViewModels
             }).ToList();
 
             int indexToInsertClass = newTargets.Count - 1;
-            newTargets.Insert(indexToInsertClass, new ClassesNodeCategoryViewModel());
-            (newTargets[indexToInsertClass] as ClassesNodeCategoryViewModel).Parent = indexToInsertClass > 0 ? newTargets[indexToInsertClass - 1] : target;
-            newTargets[indexToInsertClass].FullCategoryName = Configurations.ClassesDefaultName;
+            var classParent = indexToInsertClass > 0 ? newTargets[indexToInsertClass - 1] : target;
+            var newClass = new ClassesNodeCategoryViewModel(Configurations.ClassesDefaultName, classParent);
+            newTargets.Insert(indexToInsertClass, newClass);
 
             foreach (var newTarget in newTargets)
             {

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -359,7 +359,7 @@ namespace Dynamo.ViewModels
                     newTarget.FullCategoryName = path;
                     // Situation when we to add only one new category and item as it child.
                     // New category shoul be added to existing ClassesNodeCategoryViewModel.
-                    // Make notice ClassesNodeCategoryViewModel is always first item in 
+                    // Make notice: ClassesNodeCategoryViewModel is always first item in 
                     // all subcategories.
                     if (nameStack.Count == 0 && target.SubCategories.Count > 0 &&
                         target.SubCategories[0] is ClassesNodeCategoryViewModel)
@@ -398,7 +398,7 @@ namespace Dynamo.ViewModels
                     PlaceInNewCategory(entry, newTarget, nameStack);
                     return;
                 }
-                // If we meet ClassesNodecategoryViewModel during the search of newtarget,
+                // If we meet ClassesNodecategoryViewModel during the search of newTarget,
                 // next newTarget is specified in targetClassSuccessor.
                 if (targetClassSuccessor != null)
                     target = targetClassSuccessor;
@@ -430,7 +430,7 @@ namespace Dynamo.ViewModels
                 return cat;
             }).ToList();
 
-            // Last category in path is class. Should be created and inserted to collections 
+            // Last category in path is class. Should be created and inserted to collection 
             // classes container ClassesNodeCategoryViewModel
             int indexToInsertClass = newTargets.Count - 1;
             var classParent = indexToInsertClass > 0 ? newTargets[indexToInsertClass - 1] : target;

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -358,7 +358,7 @@ namespace Dynamo.ViewModels
                     newTarget = isRoot ? new RootNodeCategoryViewModel(next) : new NodeCategoryViewModel(next);
                     newTarget.FullCategoryName = path;
                     // Situation when we to add only one new category and item as it child.
-                    // New category shoul be added to existing ClassesNodeCategoryViewModel.
+                    // New category should be added to existing ClassesNodeCategoryViewModel.
                     // Make notice: ClassesNodeCategoryViewModel is always first item in 
                     // all subcategories.
                     if (nameStack.Count == 0 && target.SubCategories.Count > 0 &&
@@ -383,7 +383,7 @@ namespace Dynamo.ViewModels
                         targetClass.Dispose();
 
                         // Situation when we need to add only one new category and item.
-                        // We before adding it we need create new ClassesNodeCategoryViewModel
+                        // Before adding of it we need create new ClassesNodeCategoryViewModel
                         // as soon as new category will be a class.
                         if (nameStack.Count == 0)
                         {

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -341,9 +341,12 @@ namespace Dynamo.ViewModels
                 NodeCategoryViewModel targetClassSuccessor = null;
                 var newTarget = categories.FirstOrDefault(c =>
                 {
+                    // Each path has one class. We should find and save it.                    
                     if (c is ClassesNodeCategoryViewModel)
                     {
                         targetClass = c as ClassesNodeCategoryViewModel;
+                        // As soon as ClassesNodeCategoryViewModel is found we should search 
+                        // through all it classes and save result.
                         targetClassSuccessor = c.SubCategories.FirstOrDefault(c2 => c2.Name == next);
                         return targetClassSuccessor != null;
                     }
@@ -354,6 +357,10 @@ namespace Dynamo.ViewModels
                 {
                     newTarget = isRoot ? new RootNodeCategoryViewModel(next) : new NodeCategoryViewModel(next);
                     newTarget.FullCategoryName = path;
+                    // Situation when we to add only one new category and item as it child.
+                    // New category shoul be added to existing ClassesNodeCategoryViewModel.
+                    // Make notice ClassesNodeCategoryViewModel is always first item in 
+                    // all subcategories.
                     if (nameStack.Count == 0 && target.SubCategories.Count > 0 &&
                         target.SubCategories[0] is ClassesNodeCategoryViewModel)
                     {
@@ -362,6 +369,10 @@ namespace Dynamo.ViewModels
                         return;
                     }
 
+                    // We are here when target is the class. New category should be added
+                    // as child of it. So class will turn into usual category.
+                    // Here we are take class, remove it from ClassesNodeCategoryViewModel
+                    // and attach to it parrent.
                     if (targetClass != null)
                     {
                         targetClass.SubCategories.Remove(target);
@@ -371,6 +382,9 @@ namespace Dynamo.ViewModels
 
                         targetClass.Dispose();
 
+                        // Situation when we need to add only one new category and item.
+                        // We before adding it we need create new ClassesNodeCategoryViewModel
+                        // as soon as new category will be a class.
                         if (nameStack.Count == 0)
                         {
                             targetClass =
@@ -384,6 +398,8 @@ namespace Dynamo.ViewModels
                     PlaceInNewCategory(entry, newTarget, nameStack);
                     return;
                 }
+                // If we meet ClassesNodecategoryViewModel during the search of newtarget,
+                // next newTarget is specified in targetClassSuccessor.
                 if (targetClassSuccessor != null)
                     target = targetClassSuccessor;
                 else
@@ -414,6 +430,8 @@ namespace Dynamo.ViewModels
                 return cat;
             }).ToList();
 
+            // Last category in path is class. Should be created and inserted to collections 
+            // classes container ClassesNodeCategoryViewModel
             int indexToInsertClass = newTargets.Count - 1;
             var classParent = indexToInsertClass > 0 ? newTargets[indexToInsertClass - 1] : target;
             var newClass = new ClassesNodeCategoryViewModel(Configurations.ClassesDefaultName, classParent);


### PR DESCRIPTION
#### Purpose

During importing of library. package or adding new custom node user adds new categories path (sequence of `NodeCategoryViewModel`) and entry itself (`NodeSearchElementViewModel`). This operation can break nodes tree rule: parent of each class (the latest `NodeCategoryViewModel` in chain of categories) should belong to classes container `ClassesNodeCategoryViewModel`. In this PR we fix broken places.

#### Modification

Handling of situations to fix is made in functions `SearchViewModel.InsertEntry` and `SearchViewModel.PlaceInNewCategory`. Refer to code comments for more information about each case.

#### Additional references

[MAGN-5788](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5788) DUI: Fix nodes tree when new node is added

Created task [MAGN-5819](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5819) to add unit tests for this functionality.

Also this PR fixes 3 bugs found by EB:

* [MAGN-5822](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5822) DUI: Installing of Package crashes Dynamo
* [MAGN-5823](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5823) DUI: Importing of DLL crashes Dynamo
* [MAGN-5824](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5824) DUI: Creating of Custom Node crashes Dynamo
* [MAGN-5873](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5873) DUI: Importing of "Clockwork" freezes Dynamo when opening "Clockwork.Revit"

#### Reviewers

@Benglin, please, take a look.