### PR TITLE
Initially subcategories of category should be collapsed

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/BrowserItemViewModel.cs
@@ -362,8 +362,8 @@ namespace Dynamo.Wpf.ViewModels
         {
             var endState = !IsExpanded;
 
-            //foreach (var ele in this.Siblings)
-            //    ele.IsExpanded = false;
+            foreach (var ele in SubCategories.Where(cat => cat.IsExpanded == true))
+                ele.IsExpanded = false;
 
             //Walk down the tree expanding anything nested one layer deep
             //this can be removed when we have the hierachy implemented properly


### PR DESCRIPTION
#### Purpose

Each time when user expands category all subcategories should be in collapsed state. This PR implements (fixes) it.

#### Additional references

[MAGN-5847](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5847) DUI: Collapsing of category doesn't collapse next level category which is not class

#### Reviewers

@Benglin, please, take a look.