### PR TITLE
Fixing start up issue of Dynamo

### DIFF
--- a/src/DynamoCore/Nodes/NodeCategories.cs
+++ b/src/DynamoCore/Nodes/NodeCategories.cs
@@ -180,7 +180,7 @@ namespace Dynamo.Nodes
 
             foreach (TypedParameter tp in descriptor.Parameters)
             {
-                string typeOfParameter = tp.Type.Name;
+                string typeOfParameter = tp.Type.ToString();
 
                 // Check if there simbols like "[]".
                 // And remove them, according how much we found.


### PR DESCRIPTION
#### Modifications

Use `Type.ToString()` instead of `Type.Name` in `TypedParametersToString` function.

#### Unit test

Passed.

#### Reviewers

@Benglin, please, take a look.