### PR TITLE
Search of nonexistent node multiple times crashes Dynamo

### DIFF
--- a/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
+++ b/src/DynamoCoreWpf/Controls/DynamoTextBox.cs
@@ -1,23 +1,18 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Shapes;
+using System.Windows.Threading;
 using Dynamo.Controls;
-using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.Search;
 using Dynamo.UI;
-using Dynamo.UI.Views;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
-using DynCmd = Dynamo.Models.DynamoModel;
-using System.Windows.Controls.Primitives;
-using Dynamo.Core;
 using Thickness = System.Windows.Thickness;
-using System.Windows.Threading;
 
 namespace Dynamo.Nodes
 {
@@ -429,6 +424,11 @@ namespace Dynamo.UI.Controls
         {
             double gap = Configurations.ToolTipTargetGapInPixels;
             var dynamoWindow = WpfUtilities.FindUpVisualTree<DynamoView>(this.PlacementTarget);
+            if (dynamoWindow == null)
+            {
+                SetDataContext(null, true);
+                return null;
+            }
             Point targetLocation = this.PlacementTarget
                 .TransformToAncestor(dynamoWindow)
                 .Transform(new Point(0, 0));

--- a/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Search/LibrarySearchView.xaml.cs
@@ -7,7 +7,6 @@ using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
 using Dynamo.Search;
-using Dynamo.Search.SearchElements;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.ViewModels;
@@ -624,8 +623,17 @@ namespace Dynamo.UI.Views
                 return;
             }
 
-            // Update highlighted item when the ItemContainerGenerator is ready.
-            topResultListBox.ItemContainerGenerator.StatusChanged += OnTopResultListBoxIcgStatusChanged;
+            if (topResultListBox.Items.Count > 0)
+            {
+                // Update highlighted item when the ItemContainerGenerator is ready.
+                topResultListBox.ItemContainerGenerator.StatusChanged += OnTopResultListBoxIcgStatusChanged;
+            }
+            else
+            {
+                // Or hide ToolTip if topResultListBox is empty.
+                libraryToolTipPopup.SetDataContext(null, true);
+                UpdateHighlightedItem(null);
+            }
         }
 
         // ListBox.ItemContainerGenerator works asynchronously. To make sure it is ready for use


### PR DESCRIPTION
#### Purpose

Typing and removing of some nonexistent search phrase multiple times crashes Dynamo.

#### Modifications.

1. Added check on `null` of Dynamo main window.
2. ToolTip is hidden if no matches found.

#### Additional references

[MAGN-5826](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5826) DUI: Search of nonexistent node multiple times crashes Dynamo

#### Reviewers

@Benglin, please, take a look.