### PR TITLE
Restore MemberGroup expand all items functionality

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -101,6 +101,8 @@ namespace Dynamo.Wpf.ViewModels
             get { return (!string.IsNullOrEmpty(Model.Description)); }
         }
 
+        public NodeCategoryViewModel Category { get; set; }
+
         public IEnumerable<Tuple<string, string>> InputParameters
         {
             get { return Model.InputParameters; }

--- a/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/NodeSearchElementViewModel.cs
@@ -6,7 +6,6 @@ using System.Windows.Media.Imaging;
 using Dynamo.Search.SearchElements;
 using Dynamo.UI;
 using Dynamo.ViewModels;
-using Dynamo.Wpf.Services;
 using Microsoft.Practices.Prism.Commands;
 using Microsoft.Practices.Prism.ViewModel;
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchCategory.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchCategory.cs
@@ -44,7 +44,7 @@ namespace Dynamo.Search
             var group = memberGroups.FirstOrDefault(mg => mg.FullyQualifiedName == shortenedCategory);
             if (group == null)
             {
-                group = new SearchMemberGroup(shortenedCategory);
+                group = new SearchMemberGroup(shortenedCategory, memberNode.Category);
                 memberGroups.Add(group);
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchMemberGroup.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchMemberGroup.cs
@@ -40,6 +40,11 @@ namespace Dynamo.Search
             }
         }
 
+        /// <summary>
+        /// Category to which all memebers are belong to.
+        /// </summary>
+        public NodeCategoryViewModel Category { get; private set; }
+
         public IEnumerable<NodeSearchElementViewModel> Members
         {
             get
@@ -49,45 +54,42 @@ namespace Dynamo.Search
 
                 if (members.Count == 0) return new List<NodeSearchElementViewModel>();
 
-                //var firstMember = members[0] as NodeSearchElement;
+                var firstMember = members[0] as NodeSearchElementViewModel;
 
-                //// Parent items can contain 3 type of groups all together: create, action and query.
-                //// We have to show only those elements, that are in the same group.
-                //var siblings = firstMember.Parent.Items.OfType<BrowserInternalElement>().
-                //        Where(parentNode => (parentNode as NodeSearchElement).Group == firstMember.Group);
-
-                return members;
+                // Parent items can contain 3 type of groups all together: create, action and query.
+                // We have to show only those elements, that are in the same group.
+                var siblings = Category.Entries.Where(e => e.Model.Group == firstMember.Model.Group);
+                return siblings;
             }
         }
 
         private bool showAllMembers = false;
         private string delimiter = string.Format(" {0} ", Configurations.ShortenedCategoryDelimiter);
 
-        internal SearchMemberGroup(string fullyQualifiedName)
+        internal SearchMemberGroup(string fullyQualifiedName, NodeCategoryViewModel category = null)
         {
             FullyQualifiedName = fullyQualifiedName;
+            Category = category;
             members = new List<NodeSearchElementViewModel>();
         }
-
-        //some UI properties which control style of one MemberGroup
 
         internal void AddMember(NodeSearchElementViewModel node)
         {
             members.Add(node);
         }
 
-        public bool ContainsMember(NodeSearchElementViewModel member)
+        internal bool ContainsMember(NodeSearchElementViewModel member)
         {
             return Members.Any(m => m.Model.FullName == member.Model.FullName);
         }
 
-        public void ExpandAllMembers()
+        internal void ExpandAllMembers()
         {
             showAllMembers = true;
             RaisePropertyChanged("Members");
         }
 
-        public void Sort()
+        internal void Sort()
         {
             members = members.OrderBy(x => x.Name).ToList();
         }

--- a/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Search/SearchViewModel.cs
@@ -681,7 +681,7 @@ namespace Dynamo.ViewModels
                 }
 
                 var elementVM = MakeNodeSearchElementVM(node);
-                elementVM.Category = GetCategoryViewModel(node.Categories);
+                elementVM.Category = GetCategoryViewModel(libraryRoot, node.Categories);
 
                 category.AddMemberToGroup(elementVM);
             }
@@ -728,10 +728,11 @@ namespace Dynamo.ViewModels
             return elementVM;
         }
 
-        private NodeCategoryViewModel GetCategoryViewModel(IEnumerable<string> categories)
+        private static NodeCategoryViewModel GetCategoryViewModel(NodeCategoryViewModel rootCategory,
+            IEnumerable<string> categories)
         {
             var nameStack = new Stack<string>(categories.Reverse());
-            NodeCategoryViewModel target = libraryRoot;
+            NodeCategoryViewModel target = rootCategory;
             NodeCategoryViewModel newTarget = null;
             bool isCheckedForClassesCategory = false;
             while (nameStack.Any())


### PR DESCRIPTION
#### Purpose

Clicking on selected area should show all action members of "Input" category. But it is not. This PR fixes a bug. 
![image](https://cloud.githubusercontent.com/assets/8158551/5963781/c5b06b66-a7f7-11e4-9247-2cfdfed52cc1.png)

#### Modifications

To show all necessary members we need a category object. So it specified in constructor of `SearchMemberGroup`.

#### Additional references

[MAGN-6055](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6055) DUI: Clicking on "Actions" category doesn't expand all actions in search results

Review and merge this PR after https://github.com/Benglin/Dynamo/pull/276 for easier review process.

#### Reviewers

@Benglin, please, take a look.