### PR TITLE
Modified the way to find icon resources dll

### DIFF
--- a/src/DynamoCore/Library/LibraryCustomization.cs
+++ b/src/DynamoCore/Library/LibraryCustomization.cs
@@ -84,14 +84,10 @@ namespace Dynamo.DSEngine
         {
             try
             {
-                var qualifiedPath = Path.GetFullPath(assemblyLocation);
-                var fn = Path.GetFileNameWithoutExtension(qualifiedPath);
+                var fn = Path.GetFileNameWithoutExtension(assemblyLocation);
+                resourceAssemblyPath = fn + Configurations.ResourcesDLL;
 
-                fn = fn + Configurations.ResourcesDLL;
-
-                resourceAssemblyPath = Path.Combine(DynamoPathManager.Instance.MainExecPath, fn);
-
-                return File.Exists(resourceAssemblyPath);
+                return DynamoPathManager.Instance.ResolveLibraryPath(ref resourceAssemblyPath);
             }
             catch
             {


### PR DESCRIPTION
#### Purpose

The goal to support different paths to icon resources for different Revits. For example: for Revit 2014 icon resources will be situated in `Revit_2014` folder, for Revit 2015 in `Revit_2015` folder.

#### Modifications

Path to correct Revit is situated in `DynamoPathManager.AdditionalResolutionPath()`. Function `DynamoPathManager.ResolveLibraryPath` returns correct path to resource assembly.

#### Additional references

Main part of [MAGN-6106](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6106) implementation.

#### Reviewers

@Benglin, please, take a look.